### PR TITLE
FEAT: notification 관련 엔티티 및 조회 메서드 생성

### DIFF
--- a/src/main/java/com/planup/planup/domain/notification/entity/Notification.java
+++ b/src/main/java/com/planup/planup/domain/notification/entity/Notification.java
@@ -1,0 +1,54 @@
+package com.planup.planup.domain.notification.entity;
+
+import com.planup.planup.domain.global.entity.BaseTimeEntity;
+import com.planup.planup.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.tool.schema.TargetType;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Notification extends BaseTimeEntity {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "receiver_id")
+    private User receiver;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "sender_id")
+    private User sender;
+
+    @Enumerated(EnumType.STRING)
+    private NotificationType type;
+
+    private String content;
+
+    @Enumerated(EnumType.STRING)
+    private TargetType targetType; // POST, COMMENT, USER 등
+
+    private Long targetId;
+
+    private boolean isRead;
+
+    public static Notification create(User sender, User receiver, NotificationType type, String content, TargetType targetType, Long targetId) {
+        Notification n = new Notification();
+        n.sender = sender;
+        n.receiver = receiver;
+        n.type = type;
+        n.content = content;
+        n.targetType = targetType;
+        n.targetId = targetId;
+        n.isRead = false;
+        return n;
+    }
+
+    public void setRead(boolean isRead) {
+        this.isRead = isRead;
+    }
+}

--- a/src/main/java/com/planup/planup/domain/notification/entity/NotificationType.java
+++ b/src/main/java/com/planup/planup/domain/notification/entity/NotificationType.java
@@ -1,0 +1,6 @@
+package com.planup.planup.domain.notification.entity;
+
+public enum NotificationType {
+
+    GOAL,BADGE, COMMENT;
+}

--- a/src/main/java/com/planup/planup/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/planup/planup/domain/notification/repository/NotificationRepository.java
@@ -1,0 +1,19 @@
+package com.planup.planup.domain.notification.repository;
+
+import com.planup.planup.domain.notification.entity.Notification;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import javax.management.NotificationFilter;
+import java.util.List;
+
+@Repository
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+
+    // 읽지 않은 알림 조회
+    List<Notification> findByReceiverIdAndIsReadFalseIdOrderByCreatedAtDesc(Long receiverId);
+
+    // 전체 알림 조회 (읽은 것 포함)
+    List<Notification> findByReceiverIdOrderByCreatedAtDesc(Long receiverId);
+}

--- a/src/main/java/com/planup/planup/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/planup/planup/domain/notification/service/NotificationService.java
@@ -1,0 +1,17 @@
+package com.planup.planup.domain.notification.service;
+
+import com.planup.planup.domain.notification.entity.Notification;
+
+import java.util.List;
+
+public interface NotificationService {
+
+    // 읽지 않은 알림 조회 (정렬 포함)
+    List<Notification> getUnreadNotifications(Long receiverId);
+
+    // 전체 알림 조회 (정렬 포함)
+    List<Notification> getAllNotifications(Long receiverId);
+
+    // 읽음 처리
+    void markAsRead(Long notificationId);
+}

--- a/src/main/java/com/planup/planup/domain/notification/service/NotificationServiceImpl.java
+++ b/src/main/java/com/planup/planup/domain/notification/service/NotificationServiceImpl.java
@@ -1,0 +1,36 @@
+package com.planup.planup.domain.notification.service;
+
+import com.planup.planup.domain.notification.entity.Notification;
+import com.planup.planup.domain.notification.repository.NotificationRepository;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationServiceImpl implements NotificationService {
+
+    private final NotificationRepository notificationRepository;
+
+    //유저의 읽지 않은 알림을 시간 순 대로 가져온다
+    @Override
+    public List<Notification> getUnreadNotifications(Long receiverId) {
+        return notificationRepository.findByReceiverIdAndIsReadFalseIdOrderByCreatedAtDesc(receiverId);
+    }
+
+    //유저의 모든 알림을 조회한다. (시간 순대로)
+    @Override
+    public List<Notification> getAllNotifications(Long receiverId) {
+        return notificationRepository.findByReceiverIdOrderByCreatedAtDesc(receiverId);
+    }
+
+    @Override
+    public void markAsRead(Long notificationId) {
+        Notification notification = notificationRepository.findById(notificationId)
+                .orElseThrow(() -> new EntityNotFoundException("Notification not found"));
+        notification.setRead(true);
+        notificationRepository.save(notification); // JPA dirty checking or merge
+    }
+}


### PR DESCRIPTION
## 📌 개요
 notification 관련 엔티티 및 조회 메서드 생성

## ✅ 기능 설명
### notification으로 이름 변경
### 엔티티구조
 - 모든 종류의 notification은 이 엔티티에서 처리
 - notificationType: 어디서 알림이 발생했는지 보여줌 (enum)
  - 예를들어, COMMENT라면 댓글이 달려서 알림이 발생한 것임
 -  targetType: 해당 알림을 눌렀을때 어디로 이동할지에 대해 지정
  - 예를들어, GOAL이라고 지정되어 있으면 GOAL 페이지로 이동
 - targetId: 타켓의 아이디 지정. 예를 들어, GOAL의 아이디 등등
 - isRead: 읽었는지 여부
## 📎 참고 자료
<!-- 관련 링크, 참고한 문서 등 -->