### PR TITLE
[FEAT] 회원가입 시 약관 동의 기능 구현 완료

### DIFF
--- a/src/main/java/com/planup/planup/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/planup/planup/apiPayload/code/status/ErrorStatus.java
@@ -31,8 +31,13 @@ public enum ErrorStatus implements BaseErrorCode {
 
     //Report 관련 에러
     NOT_FOUND_WEEKLY_REPORT(HttpStatus.NOT_FOUND, "WEEKLY_REPORT4001", "존재하지 않는 주간 리포트입니다"),
-    NOT_FOUND_GOAL_REPORT(HttpStatus.NOT_FOUND, "GOAL_REPORT4001", "존재하지 않는 목표 리포트입니다")
+    NOT_FOUND_GOAL_REPORT(HttpStatus.NOT_FOUND, "GOAL_REPORT4001", "존재하지 않는 목표 리포트입니다"),
 
+
+    // 약관 관련 에러
+    NOT_FOUND_TERMS(HttpStatus.NOT_FOUND, "4004", "존재하지 않는 약관입니다."),
+    REQUIRED_TERMS_NOT_AGREED(HttpStatus.BAD_REQUEST, "4005", "필수 약관에 동의해야 합니다."),
+    TERMS_AGREEMENT_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "5001", "약관 동의 처리 중 오류가 발생했습니다.")
     ;
 
 

--- a/src/main/java/com/planup/planup/domain/user/controller/TermsController.java
+++ b/src/main/java/com/planup/planup/domain/user/controller/TermsController.java
@@ -1,0 +1,36 @@
+package com.planup.planup.domain.user.controller;
+
+import com.planup.planup.apiPayload.ApiResponse;
+import com.planup.planup.domain.user.dto.TermsDetailResponseDTO;
+import com.planup.planup.domain.user.dto.TermsListResponseDTO;
+import com.planup.planup.domain.user.service.TermsService;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/terms")
+@RequiredArgsConstructor
+public class TermsController {
+
+    private final TermsService termsService;
+
+    @GetMapping
+    @Operation(summary = "약관 목록 조회", description = "회원가입 시 체크박스 표시용 약관 목록을 조회합니다.")
+    public ResponseEntity<ApiResponse<List<TermsListResponseDTO>>> getTermsList() {
+        List<TermsListResponseDTO> termsList = termsService.getTermsList();
+        return ResponseEntity.ok(ApiResponse.onSuccess(termsList));
+    }
+
+    @GetMapping("/{termsId}")
+    @Operation(summary = "약관 상세 조회", description = "팝업에 표시할 약관 상세 내용을 조회합니다.")
+    public ResponseEntity<ApiResponse<TermsDetailResponseDTO>> getTermsDetail(
+            @PathVariable Long termsId) {
+
+        TermsDetailResponseDTO termsDetail = termsService.getTermsDetail(termsId);
+        return ResponseEntity.ok(ApiResponse.onSuccess(termsDetail));
+    }
+}

--- a/src/main/java/com/planup/planup/domain/user/converter/TermsConverter.java
+++ b/src/main/java/com/planup/planup/domain/user/converter/TermsConverter.java
@@ -1,0 +1,40 @@
+package com.planup.planup.domain.user.converter;
+
+import com.planup.planup.domain.user.dto.TermsDetailResponseDTO;
+import com.planup.planup.domain.user.dto.TermsListResponseDTO;
+import com.planup.planup.domain.user.entity.Terms;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Component
+public class TermsConverter {
+
+    // Terms → TermsListResponseDTO 변환
+    public static TermsListResponseDTO toTermsListResponse(Terms terms) {
+        return TermsListResponseDTO.builder()
+                .id(terms.getId())
+                .summary(terms.getSummary())
+                .isRequired(terms.getIsRequired())
+                .order(terms.getOrder())
+                .build();
+    }
+
+    // Terms → TermsDetailResponseDTO 변환
+    public static TermsDetailResponseDTO toTermsDetailResponse(Terms terms) {
+        return TermsDetailResponseDTO.builder()
+                .id(terms.getId())
+                .content(terms.getContent())
+                .build();
+    }
+
+    // List<Terms> → List<TermsListResponseDTO> 변환
+    public static List<TermsListResponseDTO> toTermsListResponseList(List<Terms> termsList) {
+        return termsList.stream()
+                .map(TermsConverter::toTermsListResponse)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/planup/planup/domain/user/converter/UserConverter.java
+++ b/src/main/java/com/planup/planup/domain/user/converter/UserConverter.java
@@ -1,0 +1,74 @@
+package com.planup.planup.domain.user.converter;
+
+import com.planup.planup.domain.user.dto.LoginResponseDTO;
+import com.planup.planup.domain.user.dto.SignupRequestDTO;
+import com.planup.planup.domain.user.dto.SignupResponseDTO;
+import com.planup.planup.domain.user.dto.TermsAgreementRequestDTO;
+import com.planup.planup.domain.user.entity.*;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+
+@Slf4j
+@Component
+public class UserConverter {
+
+    // SignupRequestDTO를 User 엔티티로 변환
+    public User toUserEntity(SignupRequestDTO request, String encodedPassword, Map<Long, Terms> termsMap) {
+        User user = User.builder()
+                    .email(request.getEmail())
+                    .password(encodedPassword)
+                    .nickname(request.getNickname())
+                    .role(Role.USER)
+                    .userActivate(UserActivate.ACTIVE)
+                    .userLevel(UserLevel.LEVEL_1)
+                    .alarmAllow(true)
+                    .profileImg(request.getProfileImg())
+                    .build();
+
+        // 약관 동의 정보도 함께 생성
+        for (TermsAgreementRequestDTO agreement : request.getAgreements()) {
+            Terms terms = termsMap.get(agreement.getTermsId());
+
+            UserTerms userTerms = UserTerms.builder()
+                    .user(user)
+                    .terms(terms)
+                    .isAgreed(agreement.isAgreed())
+                    .agreedAt(agreement.isAgreed() ? LocalDateTime.now() : null)
+                    .build();
+
+            user.getUserTermList().add(userTerms);
+        }
+
+        return user;
+    }
+
+    // User 엔티티를 SignupResponseDTO로 변환
+    public SignupResponseDTO toSignupResponseDTO(User user) {
+        return SignupResponseDTO.builder()
+                .id(user.getId())
+                .email(user.getEmail())
+                .build();
+    }
+
+    // User 엔티티를 LoginResponseDTO로 변환
+    public LoginResponseDTO toLoginResponseDTO(User user, String accessToken) {
+        return LoginResponseDTO.builder()
+                .accessToken(accessToken)
+                .nickname(user.getNickname())
+                .profileImgUrl(user.getProfileImg())
+                .build();
+    }
+
+    // TermsAgreementRequestDTO와 관련 엔티티들을 UserTerms로 변환
+    public UserTerms toUserTermsEntity(User user, Terms terms, TermsAgreementRequestDTO agreement) {
+        return UserTerms.builder()
+                .user(user)
+                .terms(terms)
+                .isAgreed(agreement.isAgreed())
+                .agreedAt(agreement.isAgreed() ? LocalDateTime.now() : null)
+                .build();
+    }
+}

--- a/src/main/java/com/planup/planup/domain/user/dto/SignupRequestDTO.java
+++ b/src/main/java/com/planup/planup/domain/user/dto/SignupRequestDTO.java
@@ -39,6 +39,6 @@ public class SignupRequestDTO {
 
     @Schema(description = "약관 동의 목록")
     @NotEmpty
-    private List<TermsAgreementDTO> agreements;
+    private List<TermsAgreementRequestDTO> agreements;
 }
 

--- a/src/main/java/com/planup/planup/domain/user/dto/TermsAgreementRequestDTO.java
+++ b/src/main/java/com/planup/planup/domain/user/dto/TermsAgreementRequestDTO.java
@@ -1,0 +1,28 @@
+package com.planup.planup.domain.user.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "약관 동의 요청")
+public class TermsAgreementRequestDTO {
+
+    @Schema(description = "약관 ID", example = "1")
+    @NotNull
+    private Long termsId;
+
+    @Schema(description = "동의 여부", example = "true")
+    @JsonProperty("isAgreed")
+    private Boolean agreed;  // Boolean으로 변경하고 필드명도 변경
+
+    // 또는 기존 필드를 유지하면서 명시적으로 getter 추가
+    public boolean isAgreed() {
+        return this.agreed != null && this.agreed;
+    }
+}

--- a/src/main/java/com/planup/planup/domain/user/dto/TermsDetailResponseDTO.java
+++ b/src/main/java/com/planup/planup/domain/user/dto/TermsDetailResponseDTO.java
@@ -1,0 +1,21 @@
+package com.planup.planup.domain.user.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "약관 상세 응답 (팝업 표시용)")
+public class TermsDetailResponseDTO {
+
+    @Schema(description = "약관 ID", example = "1")
+    private Long id;
+
+    @Schema(description = "약관 상세 내용")
+    private String content;
+}

--- a/src/main/java/com/planup/planup/domain/user/dto/TermsListResponseDTO.java
+++ b/src/main/java/com/planup/planup/domain/user/dto/TermsListResponseDTO.java
@@ -1,0 +1,27 @@
+package com.planup.planup.domain.user.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "약관 정보 응답 (체크박스 표시용)")
+public class TermsListResponseDTO {
+
+    @Schema(description = "약관 ID", example = "1")
+    private Long id;
+
+    @Schema(description = "약관 요약", example = "서비스 이용약관")
+    private String summary;
+
+    // content 필드 제외 → 응답 크기 최적화
+
+    @Schema(description = "필수 약관 여부", example = "true")
+    private Boolean isRequired;
+
+    @Schema(description = "약관 순서", example = "1")
+    private Integer order;
+
+}

--- a/src/main/java/com/planup/planup/domain/user/entity/Terms.java
+++ b/src/main/java/com/planup/planup/domain/user/entity/Terms.java
@@ -2,9 +2,12 @@ package com.planup.planup.domain.user.entity;
 
 import com.planup.planup.domain.global.entity.BaseTimeEntity;
 import jakarta.persistence.*;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
+@Getter
+@Table(name = "terms")
 @NoArgsConstructor
 public class Terms extends BaseTimeEntity {
 

--- a/src/main/java/com/planup/planup/domain/user/entity/User.java
+++ b/src/main/java/com/planup/planup/domain/user/entity/User.java
@@ -45,8 +45,8 @@ public class User extends BaseTimeEntity {
     private String inviteCode;
 
     // 연관 관계
-    @OneToMany(mappedBy = "user")
-    private List<UserTerms> userTermList;
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
+    private List<UserTerms> userTermList = new ArrayList<>();
 
     @OneToMany(mappedBy = "user")
     private List<InvitedUser> invitedUserList;

--- a/src/main/java/com/planup/planup/domain/user/entity/UserTerms.java
+++ b/src/main/java/com/planup/planup/domain/user/entity/UserTerms.java
@@ -2,9 +2,7 @@ package com.planup.planup.domain.user.entity;
 
 import com.planup.planup.domain.global.entity.BaseTimeEntity;
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.time.LocalDateTime;
 
@@ -12,6 +10,8 @@ import java.time.LocalDateTime;
 @Entity
 @Table(name = "user_terms")
 @Getter
+@Setter
+@Builder
 @AllArgsConstructor
 @NoArgsConstructor
 public class UserTerms extends BaseTimeEntity {

--- a/src/main/java/com/planup/planup/domain/user/repository/TermsRepository.java
+++ b/src/main/java/com/planup/planup/domain/user/repository/TermsRepository.java
@@ -1,0 +1,14 @@
+package com.planup.planup.domain.user.repository;
+
+import com.planup.planup.domain.user.entity.Terms;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface TermsRepository extends JpaRepository<Terms, Long> {
+
+    List<Terms> findAllByOrderByOrderAsc();
+    List<Terms> findByIsRequiredTrue();
+}

--- a/src/main/java/com/planup/planup/domain/user/repository/UserTermsRepository.java
+++ b/src/main/java/com/planup/planup/domain/user/repository/UserTermsRepository.java
@@ -1,0 +1,9 @@
+package com.planup.planup.domain.user.repository;
+
+import com.planup.planup.domain.user.entity.UserTerms;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserTermsRepository extends JpaRepository<UserTerms, Long> {
+}

--- a/src/main/java/com/planup/planup/domain/user/service/TermsService.java
+++ b/src/main/java/com/planup/planup/domain/user/service/TermsService.java
@@ -1,0 +1,18 @@
+package com.planup.planup.domain.user.service;
+
+import com.planup.planup.domain.user.dto.TermsAgreementRequestDTO;
+import com.planup.planup.domain.user.dto.TermsDetailResponseDTO;
+import com.planup.planup.domain.user.dto.TermsListResponseDTO;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public interface TermsService {
+
+    // 모든 약관 목록 조회 (체크박스 표시용)
+    List<TermsListResponseDTO> getTermsList();
+
+    // 특정 약관의 상세 내용 조회 (팝업 표시용)
+    TermsDetailResponseDTO getTermsDetail(Long termsId);
+}

--- a/src/main/java/com/planup/planup/domain/user/service/TermsServiceImpl.java
+++ b/src/main/java/com/planup/planup/domain/user/service/TermsServiceImpl.java
@@ -1,0 +1,40 @@
+package com.planup.planup.domain.user.service;
+
+import com.planup.planup.apiPayload.code.status.ErrorStatus;
+import com.planup.planup.apiPayload.exception.custom.UserException;
+import com.planup.planup.domain.user.converter.TermsConverter;
+import com.planup.planup.domain.user.dto.TermsDetailResponseDTO;
+import com.planup.planup.domain.user.dto.TermsListResponseDTO;
+import com.planup.planup.domain.user.entity.Terms;
+import com.planup.planup.domain.user.repository.TermsRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import java.util.List;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class TermsServiceImpl implements TermsService {
+
+    private final TermsRepository termsRepository;
+
+    @Override
+    @Transactional
+    public List<TermsListResponseDTO> getTermsList() {
+        List<Terms> termsList = termsRepository.findAllByOrderByOrderAsc();
+
+        return TermsConverter.toTermsListResponseList(termsList);
+    }
+
+    @Override
+    @Transactional
+    public TermsDetailResponseDTO getTermsDetail(Long termsId) {
+        Terms terms = termsRepository.findById(termsId)
+                .orElseThrow(() -> new UserException(ErrorStatus.NOT_FOUND_TERMS));
+
+        return TermsConverter.toTermsDetailResponse(terms);
+    }
+
+}

--- a/src/main/java/com/planup/planup/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/planup/planup/domain/user/service/UserServiceImpl.java
@@ -2,23 +2,20 @@ package com.planup.planup.domain.user.service;
 
 import com.planup.planup.apiPayload.code.status.ErrorStatus;
 import com.planup.planup.apiPayload.exception.custom.UserException;
-import com.planup.planup.domain.user.dto.LoginRequestDTO;
-import com.planup.planup.domain.user.dto.LoginResponseDTO;
-import com.planup.planup.domain.user.dto.SignupRequestDTO;
-import com.planup.planup.domain.user.dto.SignupResponseDTO;
-import com.planup.planup.domain.user.entity.Role;
-import com.planup.planup.domain.user.entity.User;
-import com.planup.planup.domain.user.entity.UserActivate;
-import com.planup.planup.domain.user.entity.UserLevel;
+import com.planup.planup.domain.user.dto.*;
+import com.planup.planup.domain.user.entity.*;
+import com.planup.planup.domain.user.repository.TermsRepository;
 import com.planup.planup.domain.user.repository.UserRepository;
+import com.planup.planup.domain.user.repository.UserTermsRepository;
 import com.planup.planup.validation.JwtUtil;
-import lombok.AllArgsConstructor;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 @Service
@@ -30,7 +27,8 @@ public class UserServiceImpl implements UserService {
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
     private final JwtUtil jwtUtil;
-
+    private final TermsRepository termsRepository;
+    private final UserTermsRepository userTermsRepository;
 
     @Override
     public User getUserbyUserId(Long userId) {
@@ -68,12 +66,7 @@ public class UserServiceImpl implements UserService {
     @Transactional
     public boolean checkPassword(Long userId, String password) {
         User user = getUserbyUserId(userId);
-
-        if (passwordEncoder.matches(password, user.getPassword())) {
-            return true;
-        } else {
-            return false;
-        }
+        return passwordEncoder.matches(password, user.getPassword());
     }
 
     @Override
@@ -93,32 +86,34 @@ public class UserServiceImpl implements UserService {
             throw new UserException(ErrorStatus.USER_EMAIL_ALREADY_EXISTS);
         }
 
-        // 2. 비밀번호 확인 검증
+        // 비밀번호 확인 검증
         if (!request.getPassword().equals(request.getPasswordCheck())) {
             throw new UserException(ErrorStatus.PASSWORD_MISMATCH);
         }
 
-        // 3. 비밀번호 암호화
+        // 필수 약관 동의 검증
+        validateRequiredTerms(request.getAgreements());
+
+        // 비밀번호 암호화
         String encodedPassword = passwordEncoder.encode(request.getPassword());
 
-        // 4. User 엔티티 생성 및 저장
+        // User 엔티티 생성
         User user = User.builder()
                 .email(request.getEmail())
                 .password(encodedPassword)
                 .nickname(request.getNickname())
-                .role(Role.USER)  // 기본 역할
-                .userActivate(UserActivate.ACTIVE)  // 활성 상태
-                .userLevel(UserLevel.LEVEL_1)  // 기본 레벨
-                .alarmAllow(true)  // 기본 알림 허용
+                .role(Role.USER)
+                .userActivate(UserActivate.ACTIVE)
+                .userLevel(UserLevel.LEVEL_1)
+                .alarmAllow(true)
                 .profileImg(request.getProfileImg())
                 .build();
 
         User savedUser = userRepository.save(user);
 
-        // 5. 약관 동의 처리 (추후 구현)
-        // TODO: 약관 동의 저장 로직 구현 필요
+        // 약관 동의 추가
+        addTermsAgreements(savedUser, request.getAgreements());
 
-        // 6. 응답 DTO 생성
         return SignupResponseDTO.builder()
                 .id(savedUser.getId())
                 .email(savedUser.getEmail())
@@ -128,24 +123,24 @@ public class UserServiceImpl implements UserService {
     @Override
     @Transactional
     public LoginResponseDTO login(LoginRequestDTO request) {
-        // 1. 이메일로 사용자 조회
+        //  이메일로 사용자 조회
         User user = userRepository.findByEmail(request.getEmail())
                 .orElseThrow(() -> new UserException(ErrorStatus.NOT_FOUND_USER));
 
-        // 2. 비밀번호 검증
+        // 비밀번호 검증
         if (!passwordEncoder.matches(request.getPassword(), user.getPassword())) {
             throw new UserException(ErrorStatus.INVALID_CREDENTIALS);
         }
 
-        // 3. 사용자 상태 확인
+        // 사용자 상태 확인
         if (user.getUserActivate() != UserActivate.ACTIVE) {
             throw new UserException(ErrorStatus.USER_INACTIVE);
         }
 
-        // 4. JWT 토큰 생성
+        // JWT 토큰 생성
         String accessToken = jwtUtil.generateToken(user.getEmail(), user.getRole().toString());
 
-        // 5. 응답 DTO 생성
+        // 응답 DTO 생성
         return LoginResponseDTO.builder()
                 .accessToken(accessToken)
                 .nickname(user.getNickname())
@@ -153,4 +148,40 @@ public class UserServiceImpl implements UserService {
                 .build();
     }
 
+    private void validateRequiredTerms(List<TermsAgreementRequestDTO> agreements) {
+
+        // 필수 약관 목록 조회
+        List<Terms> requiredTerms = termsRepository.findByIsRequiredTrue();
+
+        // 동의한 필수 약관 ID 목록
+        List<Long> agreedRequiredTermsIds = agreements.stream()
+                .filter(TermsAgreementRequestDTO::isAgreed)
+                .map(TermsAgreementRequestDTO::getTermsId)
+                .toList();
+
+        // 필수 약관 중 동의하지 않은 것이 있는지 확인
+        for (Terms requiredTerm : requiredTerms) {
+            if (!agreedRequiredTermsIds.contains(requiredTerm.getId())) {
+                throw new UserException(ErrorStatus.REQUIRED_TERMS_NOT_AGREED);
+            }
+        }
+    }
+
+    private void addTermsAgreements(User user, List<TermsAgreementRequestDTO> agreements) {
+
+        for (TermsAgreementRequestDTO agreement : agreements) {
+
+            Terms terms = termsRepository.findById(agreement.getTermsId())
+                    .orElseThrow(() -> new UserException(ErrorStatus.NOT_FOUND_TERMS));
+
+            UserTerms userTerms = UserTerms.builder()
+                    .user(user)
+                    .terms(terms)
+                    .isAgreed(agreement.isAgreed())
+                    .agreedAt(agreement.isAgreed() ? LocalDateTime.now() : null)
+                    .build();
+
+            UserTerms saved = userTermsRepository.save(userTerms);
+        }
+    }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,24 +3,22 @@ server:
 
 spring:
   datasource:
-#    url: jdbc:mysql://${DB_HOST}:${DB_PORT}/${DB_NAME}?serverTimezone=Asia/Seoul&useLegacyDatetimeCode=false
-#    driverClassName: com.mysql.cj.jdbc.Driver
-#    username: ${DB_USER}
-#    password: ${DB_PASSWORD}
-    url: jdbc:mysql://localhost:3306/plan_up?serverTimezone=Asia/Seoul&useSSL=false&allowPublicKeyRetrieval=true
-    username: root
-    password: 1234
-    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:mysql://${DB_HOST}:${DB_PORT}/${DB_NAME}?serverTimezone=Asia/Seoul&useLegacyDatetimeCode=false
+    driverClassName: com.mysql.cj.jdbc.Driver
+    username: ${DB_USER}
+    password: ${DB_PASSWORD}
+
     hikari:
       maximum-pool-size: 10         # 최대 커넥션 개수
+
   jpa:
     hibernate:
+      dialect: org.hibernate.dialect.MySQLDialect
       ddl-auto: update
     properties:
       hibernate:
-        dialect: org.hibernate.dialect.MySQLDialect
         jdbc:
-          time_zone: Asia/Seoul
+        time_zone: Asia/Seoul
 
   application:
     name: planup


### PR DESCRIPTION
## 📌 개요
회원가입 프로세스에 약관 동의 기능을 통합하여 구현했습니다.

## ✅ 기능 설명
- 약관 목록 조회 API (`GET /terms`) 구현
- 약관 상세 조회 API (`GET /terms/{termsId}`) 구현
- 회원가입 시 필수/선택 약관 동의 처리
- UserTerms 엔티티를 통한 약관 동의 이력 저장
- 약관 동의 데이터 검증 및 저장

Closes #33