### PR TITLE
[FIX] 프로필 이미지 업로드 API 중복 제거

### DIFF
--- a/src/main/java/com/planup/planup/domain/user/controller/UserController.java
+++ b/src/main/java/com/planup/planup/domain/user/controller/UserController.java
@@ -55,14 +55,7 @@ public class UserController {
         return ApiResponse.onSuccess(true);
     }
 
-    @Operation(summary = "프로필 사진 변경", description = "마이페이지에서 프로필 사진 변경")
-    @PostMapping("/mypage/profile/image")
-    public ApiResponse<String> updateProfileImage(
-            @RequestParam Long userId,
-            @RequestPart MultipartFile imageFile) {
-        String imageUrl = userService.updateProfileImage(userId, imageFile);
-        return ApiResponse.onSuccess(imageUrl);
-    }
+
 
     @Operation(summary = "유저 정보 조회", description = "유저의 상세 정보 조회")
     @GetMapping("/users/info")

--- a/src/main/java/com/planup/planup/domain/user/service/UserService.java
+++ b/src/main/java/com/planup/planup/domain/user/service/UserService.java
@@ -17,7 +17,7 @@ public interface UserService {
 
     void updatePassword(Long userId, String password);
 
-    String updateProfileImage(Long userId, MultipartFile imageFile);
+
 
     UserInfoResponseDTO getUserInfo(Long userId);
 

--- a/src/main/java/com/planup/planup/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/planup/planup/domain/user/service/UserServiceImpl.java
@@ -111,27 +111,7 @@ public class UserServiceImpl implements UserService {
         user.setPassword(encodedPassword);
     }
 
-    @Override
-    @Transactional
-    public String updateProfileImage(Long userId, MultipartFile imageFile) {
-        User user = getUserbyUserId(userId);
 
-        // 파일 저장 경로 설정 (예: /uploads/profile/)
-        String uploadDir = "/uploads/profile/";
-        String fileName = userId + "_" + imageFile.getOriginalFilename();
-        Path filePath = Paths.get(uploadDir + fileName);
-
-        try {
-            Files.createDirectories(filePath.getParent());
-            imageFile.transferTo(filePath.toFile());
-            // DB에 경로 저장
-            user.setProfileImg(filePath.toString());
-            // userRepository.save(user); // 필요시 저장
-            return filePath.toString();
-        } catch (Exception e) {
-            throw new RuntimeException("프로필 이미지 저장 실패", e);
-        }
-    }
 
     @Override
     @Transactional(readOnly = true)


### PR DESCRIPTION
## 📋 변경 사항
- 기존에 마이페이지에서 프로필 변경하는 api (updateProfileImage) 를 삭제
- 회원가입 시 프로필 사진을 업로드하거나 변경하는 api 사용으로 통일