### PR TITLE
[FIX] 친구 리스트 조회 시 goalCnt, todayTime, isNewPhotoVerify 실제 데이터 구현 및 중복 제거

### DIFF
--- a/src/main/java/com/planup/planup/domain/friend/converter/FriendConverter.java
+++ b/src/main/java/com/planup/planup/domain/friend/converter/FriendConverter.java
@@ -2,12 +2,18 @@ package com.planup.planup.domain.friend.converter;
 
 import com.planup.planup.domain.friend.dto.FriendResponseDTO;
 import com.planup.planup.domain.user.entity.User;
+import com.planup.planup.domain.verification.service.TimerVerificationService;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
 
+import java.time.LocalTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
 @Slf4j
+@RequiredArgsConstructor
+@Component
 public class FriendConverter {
 
     public static FriendResponseDTO.FriendInfoSummary toFriendSummary(User friend) {
@@ -40,5 +46,27 @@ public class FriendConverter {
                 .cnt(size)
                 .friendInfoSummaryList(summeryList)
                 .build();
+    }
+
+    private LocalTime calculateTodayTotalTime(User user) {
+        try {
+            // 사용자의 모든 목표에 대해 오늘 타이머 시간을 합계
+            long totalSeconds = user.getUserGoals().stream()
+                    .mapToLong(userGoal -> {
+                        try {
+                            LocalTime goalTime = timerVerificationService.getTodayTotalTime(user.getId(), userGoal.getGoal().getId());
+                            return goalTime.toSecondOfDay();
+                        } catch (Exception e) {
+                            log.warn("사용자 {} 목표 {} 타이머 시간 조회 실패: {}", user.getNickname(), userGoal.getGoal().getId(), e.getMessage());
+                            return 0L;
+                        }
+                    })
+                    .sum();
+            
+            return LocalTime.ofSecondOfDay(totalSeconds);
+        } catch (Exception e) {
+            log.warn("사용자 {} 오늘 타이머 시간 계산 실패: {}", user.getNickname(), e.getMessage());
+            return LocalTime.of(0, 0, 0);
+        }
     }
 }

--- a/src/main/java/com/planup/planup/domain/friend/converter/FriendConverter.java
+++ b/src/main/java/com/planup/planup/domain/friend/converter/FriendConverter.java
@@ -36,7 +36,7 @@ public class FriendConverter {
                 .nickname(friend.getNickname()) 
                 .goalCnt(goalCnt)
                 .todayTime(todayTime)
-                .isNewPhotoVerify(true) // 아직 하드코딩
+                .isNewPhotoVerify(isNewPhotoVerify)
                 .build();
     }
 

--- a/src/main/java/com/planup/planup/domain/friend/converter/FriendConverter.java
+++ b/src/main/java/com/planup/planup/domain/friend/converter/FriendConverter.java
@@ -3,6 +3,7 @@ package com.planup.planup.domain.friend.converter;
 import com.planup.planup.domain.friend.dto.FriendResponseDTO;
 import com.planup.planup.domain.user.entity.User;
 import com.planup.planup.domain.verification.service.TimerVerificationService;
+import com.planup.planup.domain.verification.repository.PhotoVerificationRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -17,6 +18,7 @@ import java.util.stream.Collectors;
 public class FriendConverter {
 
     private final TimerVerificationService timerVerificationService;
+    private final PhotoVerificationRepository photoVerificationRepository;
 
     public FriendResponseDTO.FriendInfoSummary toFriendSummary(User friend) {
         // goalCnt: 실제 사용자의 목표 개수
@@ -24,6 +26,9 @@ public class FriendConverter {
         
         // todayTime: 오늘 타이머 시간 계산 (모든 목표의 합계)
         LocalTime todayTime = calculateTodayTotalTime(friend);
+
+        // isNewPhotoVerify: 오늘 사진 인증 여부 확인
+        boolean isNewPhotoVerify = checkTodayPhotoVerification(friend);
         
         return FriendResponseDTO.FriendInfoSummary
                 .builder()
@@ -77,6 +82,15 @@ public class FriendConverter {
         } catch (Exception e) {
             log.warn("사용자 {} 오늘 타이머 시간 계산 실패: {}", user.getNickname(), e.getMessage());
             return LocalTime.of(0, 0, 0);
+        }
+    }
+
+    private boolean checkTodayPhotoVerification(User user) {
+        try {
+            return photoVerificationRepository.existsTodayPhotoVerificationByUserId(user.getId());
+        } catch (Exception e) {
+            log.warn("사용자 {} 오늘 사진 인증 조회 실패: {}", user.getNickname(), e.getMessage());
+            return false;
         }
     }
 }

--- a/src/main/java/com/planup/planup/domain/friend/converter/FriendConverter.java
+++ b/src/main/java/com/planup/planup/domain/friend/converter/FriendConverter.java
@@ -12,29 +12,36 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 @Slf4j
-@RequiredArgsConstructor
 @Component
+@RequiredArgsConstructor
 public class FriendConverter {
 
-    public static FriendResponseDTO.FriendInfoSummary toFriendSummary(User friend) {
+    private final TimerVerificationService timerVerificationService;
+
+    public FriendResponseDTO.FriendInfoSummary toFriendSummary(User friend) {
+        // goalCnt: 실제 사용자의 목표 개수
+        int goalCnt = friend.getUserGoals().size();
+        
+        // todayTime: 오늘 타이머 시간 계산 (모든 목표의 합계)
+        LocalTime todayTime = calculateTodayTotalTime(friend);
+        
         return FriendResponseDTO.FriendInfoSummary
                 .builder()
                 .id(friend.getId())
                 .nickname(friend.getNickname()) 
-                .goalCnt(0)
-                .isNewPhotoVerify(true)
+                .goalCnt(goalCnt)
+                .todayTime(todayTime)
+                .isNewPhotoVerify(true) // 아직 하드코딩
                 .build();
-
     }
 
-    public static FriendResponseDTO.FriendInfoInChallengeCreate toFriendInfoChallenge(User friend) {
+    public FriendResponseDTO.FriendInfoInChallengeCreate toFriendInfoChallenge(User friend) {
         return FriendResponseDTO.FriendInfoInChallengeCreate
                 .builder()
                 .id(friend.getId())
                 .nickname(friend.getNickname())
                 .goalCnt(friend.getUserGoals().size())
                 .build();
-
     }
 
     public FriendResponseDTO.FriendSummaryList toFriendSummaryList(List<User> friends) {
@@ -47,7 +54,10 @@ public class FriendConverter {
                 .friendInfoSummaryList(summeryList)
                 .build();
     }
-
+    
+    /**
+     * 사용자의 모든 목표에 대한 오늘 타이머 시간을 합계하여 계산
+     */
     private LocalTime calculateTodayTotalTime(User user) {
         try {
             // 사용자의 모든 목표에 대해 오늘 타이머 시간을 합계

--- a/src/main/java/com/planup/planup/domain/friend/converter/FriendConverter.java
+++ b/src/main/java/com/planup/planup/domain/friend/converter/FriendConverter.java
@@ -37,8 +37,8 @@ public class FriendConverter {
 
     }
 
-        public static FriendResponseDTO.FriendSummaryList toFriendSummaryList(List<User> friends) {
-        List<FriendResponseDTO.FriendInfoSummary> summeryList = friends.stream().map(FriendConverter::toFriendSummary).collect(Collectors.toList());
+    public FriendResponseDTO.FriendSummaryList toFriendSummaryList(List<User> friends) {
+        List<FriendResponseDTO.FriendInfoSummary> summeryList = friends.stream().map(this::toFriendSummary).collect(Collectors.toList());
         int size = summeryList.size();
 
         return FriendResponseDTO.FriendSummaryList

--- a/src/main/java/com/planup/planup/domain/friend/service/FriendServiceImpl.java
+++ b/src/main/java/com/planup/planup/domain/friend/service/FriendServiceImpl.java
@@ -24,6 +24,7 @@ public class FriendServiceImpl implements FriendService {
 
     private final FriendRepository friendRepository;
     private final UserService userService;
+    private final FriendConverter friendConverter;
 
     @Override
     @Transactional(readOnly = true) 
@@ -38,8 +39,7 @@ public class FriendServiceImpl implements FriendService {
                 .map(f -> f.getFriend().equals(user) ? f.getUser() : f.getFriend())
                 .collect(Collectors.toList());
 
-
-        return List.of(FriendConverter.toFriendSummaryList(list));
+        return List.of(friendConverter.toFriendSummaryList(list));
     }
 
     @Override

--- a/src/main/java/com/planup/planup/domain/friend/service/FriendServiceImpl.java
+++ b/src/main/java/com/planup/planup/domain/friend/service/FriendServiceImpl.java
@@ -37,6 +37,7 @@ public class FriendServiceImpl implements FriendService {
         //Friend 객체의 friend, user 중 내가 아닌 친구를 뽑는다.
         List<User> list = friendList.stream()
                 .map(f -> f.getFriend().equals(user) ? f.getUser() : f.getFriend())
+                .distinct() // 중복 제거
                 .collect(Collectors.toList());
 
         return List.of(friendConverter.toFriendSummaryList(list));
@@ -134,7 +135,7 @@ public class FriendServiceImpl implements FriendService {
         }
 
         return friendRequests.stream()
-                .map(f -> FriendConverter.toFriendSummary(f.getUser()))
+                .map(f -> friendConverter.toFriendSummary(f.getUser()))
                 .collect(Collectors.toList());
     }
 
@@ -221,7 +222,8 @@ public class FriendServiceImpl implements FriendService {
     public List<FriendResponseDTO.FriendInfoInChallengeCreate> getFrinedListInChallenge(Long userId) {
         List<Friend> friendList = friendRepository.findByStatusAndUserIdOrStatusAndFriendIdOrderByCreatedAtDesc(FriendStatus.ACCEPTED, userId, FriendStatus.ACCEPTED, userId);
         List<FriendResponseDTO.FriendInfoInChallengeCreate> dtoList = friendList.stream()
-                .map(friend -> FriendConverter.toFriendInfoChallenge(friend.getFriend())) // 또는 getUser()
+                .map(friend -> friendConverter.toFriendInfoChallenge(friend.getFriend())) // 또는 getUser()
+                .distinct()
                 .collect(Collectors.toList());
         return dtoList;
     }

--- a/src/main/java/com/planup/planup/domain/verification/repository/PhotoVerificationRepository.java
+++ b/src/main/java/com/planup/planup/domain/verification/repository/PhotoVerificationRepository.java
@@ -2,8 +2,15 @@ package com.planup.planup.domain.verification.repository;
 
 import com.planup.planup.domain.verification.entity.PhotoVerification;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface PhotoVerificationRepository extends JpaRepository<PhotoVerification, Long> {
+
+    @Query("SELECT COUNT(p) > 0 FROM PhotoVerification p " +
+           "WHERE p.userGoal.user.id = :userId " +
+           "AND DATE(p.createdAt) = CURRENT_DATE")
+    boolean existsTodayPhotoVerificationByUserId(@Param("userId") Long userId);
 }


### PR DESCRIPTION
## 📌 개요
- 친구 리스트 조회 시 하드코딩된 값들을 실제 데이터를 반영하도록 구현. 
- goalCnt, todayTime, isNewPhotoVerify 필드가 모두 실제 사용자 데이터를 기반으로 계산됨.

## ✅ 기능 설명
- FriendConverter 개선
- 실제 데이터 계산 구현
- PhotoVerificationRepository 확장
- 중복 제거: 친구 목록에서 같은 친구가 두 번 나타나는 문제 해결