### PR TITLE
[FIX] 이메일 중복 확인 로직 수정 

### DIFF
--- a/src/main/java/com/planup/planup/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/planup/planup/apiPayload/code/status/ErrorStatus.java
@@ -27,7 +27,6 @@ public enum ErrorStatus implements BaseErrorCode {
     // User 에러
     NOT_FOUND_USER(HttpStatus.NOT_FOUND, "USER4001", "존재하지 않는 유저입니다"),
     EXIST_NICKNAME(HttpStatus.CONFLICT, "USER4002", "이미 존재하는 닉네임입니다"),
-    EXIST_EMAIL(HttpStatus.CONFLICT, "USER4003", "이미 존재하는 이메일입니다"),
 
     // 로그인, 회원가입 관련 에러
     USER_EMAIL_ALREADY_EXISTS(HttpStatus.CONFLICT, "USER4003", "이미 존재하는 이메일입니다"),

--- a/src/main/java/com/planup/planup/domain/user/controller/UserController.java
+++ b/src/main/java/com/planup/planup/domain/user/controller/UserController.java
@@ -156,7 +156,7 @@ public class UserController {
     public ApiResponse<EmailSendResponseDTO> resendVerificationEmail (@RequestBody @Valid EmailVerificationRequestDTO request) {
 
         if (emailService.isEmailVerified(request.getEmail())) {
-            throw new UserException(ErrorStatus.USER_EMAIL_ALREADY_EXISTS);
+            throw new UserException(ErrorStatus. EMAIL_ALREADY_VERIFIED);
         }
         // 인증메일 재발송
         String verificationToken = emailService.resendVerificationEmail(request.getEmail());

--- a/src/main/java/com/planup/planup/domain/user/dto/WithdrawalRequestDTO.java
+++ b/src/main/java/com/planup/planup/domain/user/dto/WithdrawalRequestDTO.java
@@ -3,9 +3,15 @@ package com.planup.planup.domain.user.dto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Builder
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
 public class WithdrawalRequestDTO {
 
     @Schema(description = "탈퇴 이유", example = "서비스 불만족")

--- a/src/main/java/com/planup/planup/domain/user/dto/WithdrawalResponseDTO.java
+++ b/src/main/java/com/planup/planup/domain/user/dto/WithdrawalResponseDTO.java
@@ -1,9 +1,15 @@
 package com.planup.planup.domain.user.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Builder
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
 public class WithdrawalResponseDTO {
 
     @Schema(description = "탈퇴 성공 여부", example = "true")

--- a/src/main/java/com/planup/planup/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/planup/planup/domain/user/service/UserServiceImpl.java
@@ -130,9 +130,7 @@ public class UserServiceImpl implements UserService {
     @Transactional
     public SignupResponseDTO signup(SignupRequestDTO request) {
         // 이메일 중복 체크
-        if (userRepository.existsByEmail(request.getEmail())) {
-            throw new UserException(ErrorStatus.USER_EMAIL_ALREADY_EXISTS);
-        }
+        checkEmail(request.getEmail());
 
         // 비밀번호 확인 검증
         if (!request.getPassword().equals(request.getPasswordCheck())) {
@@ -226,7 +224,7 @@ public class UserServiceImpl implements UserService {
 
         // 다른 사용자가 이미 사용 중인 이메일인지 확인
         if (userRepository.existsByEmail(newEmail)) {
-            throw new UserException(ErrorStatus.EXIST_EMAIL);
+            throw new UserException(ErrorStatus.USER_EMAIL_ALREADY_EXISTS);
         }
 
         user.setEmail(newEmail);
@@ -449,12 +447,12 @@ public class UserServiceImpl implements UserService {
         }
     }
 
-
     @Override
     @Transactional
     public void checkEmail(String email){
-        if (userRepository.existsByEmail(email)) {
-            throw new UserException(ErrorStatus.EXIST_EMAIL);
+        Optional<User> user = userRepository.findByEmail(email);
+        if (user.isPresent() && user.get().getUserActivate() == UserActivate.ACTIVE) {
+            throw new UserException(ErrorStatus.USER_EMAIL_ALREADY_EXISTS);
         }
     }
 }


### PR DESCRIPTION
## 📌 개요
테스트 편의성을 위한 이메일 중복 확인 로직 수정 

## ✅ 기능 설명
- active 상태인 유저만 중복 여부를 확인하도록 수정 

## 논의 사항 
- 테스트 정상 작동하려면 email 필드(User table)의 Unique 제약 조건 삭제 필요 