### PR TITLE
[FEAT] 이메일 인증 성공 여부 페이지 추가 

### DIFF
--- a/src/main/java/com/planup/planup/domain/user/service/EmailService.java
+++ b/src/main/java/com/planup/planup/domain/user/service/EmailService.java
@@ -19,4 +19,8 @@ public interface EmailService {
 
     // 이메일 인증 토큰 정리
     void clearVerificationToken(String email);
+
+    String createSuccessHtml(String email, String deepLinkUrl);
+
+    String createFailureHtml();
 }

--- a/src/main/java/com/planup/planup/domain/user/service/EmailServiceImpl.java
+++ b/src/main/java/com/planup/planup/domain/user/service/EmailServiceImpl.java
@@ -131,6 +131,7 @@ public class EmailServiceImpl implements EmailService {
 
         } catch (Exception e) {
             throw new RuntimeException("이메일 발송 실패", e);
+
         }
     }
 
@@ -162,5 +163,166 @@ public class EmailServiceImpl implements EmailService {
                 </p>
             </div>
             """.formatted(verificationUrl);
+    }
+
+    @Override
+    public String createSuccessHtml(String email, String deepLinkUrl) {
+        return """
+        <!DOCTYPE html>
+        <html lang="ko">
+        <head>
+            <meta charset="UTF-8">
+            <meta name="viewport" content="width=device-width, initial-scale=1.0">
+            <title>Plan-Up 이메일 인증</title>
+            <style>
+                body {
+                    margin: 0;
+                    padding: 20px;
+                    font-family: Arial, sans-serif;
+                    background-color: #f5f5f5;
+                }
+                .container {
+                    max-width: 600px;
+                    margin: 0 auto;
+                    padding: 20px;
+                    background: white;
+                    border-radius: 8px;
+                    box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+                }
+                .header {
+                    text-align: center;
+                    margin-bottom: 30px;
+                }
+                .header h1 {
+                    color: #4285f4;
+                    font-size: 2rem;
+                    margin: 0;
+                }
+                .content {
+                    text-align: center;
+                }
+                h2 {
+                    color: #333;
+                    margin-bottom: 20px;
+                    font-size: 1.5rem;
+                }
+                p {
+                    color: #666;
+                    line-height: 1.6;
+                    margin-bottom: 20px;
+                    font-size: 1rem;
+                }
+                .footer {
+                    margin-top: 40px;
+                    padding-top: 20px;
+                    border-top: 1px solid #eee;
+                }
+                .footer p {
+                    color: #999;
+                    font-size: 14px;
+                    margin: 5px 0;
+                }
+            </style>
+        </head>
+        <body>
+            <div class="container">
+                <div class="header">
+                    <h1>Plan-Up</h1>
+                </div>
+                <div class="content">
+                    <h2>이메일 인증 완료</h2>
+                    <p>
+                        인증이 성공하였습니다!<br>
+                        Plan-Up 앱으로 돌아가서 다음 단계를 진행해주세요.
+                    </p>
+                </div>
+                <div class="footer">
+                    <p>* 이 창을 닫고 앱으로 돌아가주세요.</p>
+                </div>
+            </div>
+        </body>
+        </html>
+        """;
+    }
+
+    @Override
+    public String createFailureHtml() {
+        return """
+        <!DOCTYPE html>
+        <html lang="ko">
+        <head>
+            <meta charset="UTF-8">
+            <meta name="viewport" content="width=device-width, initial-scale=1.0">
+            <title>Plan-Up 이메일 인증</title>
+            <style>
+                body {
+                    margin: 0;
+                    padding: 20px;
+                    font-family: Arial, sans-serif;
+                    background-color: #f5f5f5;
+                }
+                .container {
+                    max-width: 600px;
+                    margin: 0 auto;
+                    padding: 20px;
+                    background: white;
+                    border-radius: 8px;
+                    box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+                }
+                .header {
+                    text-align: center;
+                    margin-bottom: 30px;
+                }
+                .header h1 {
+                    color: #4285f4;
+                    font-size: 2rem;
+                    margin: 0;
+                }
+                .content {
+                    text-align: center;
+                }
+                h2 {
+                    color: #333;
+                    margin-bottom: 20px;
+                    font-size: 1.5rem;
+                }
+                p {
+                    color: #666;
+                    line-height: 1.6;
+                    margin-bottom: 20px;
+                    font-size: 1rem;
+                }
+                .footer {
+                    margin-top: 40px;
+                    padding-top: 20px;
+                    border-top: 1px solid #eee;
+                }
+                .footer p {
+                    color: #999;
+                    font-size: 14px;
+                    margin: 5px 0;
+                }
+            </style>
+        </head>
+        <body>
+            <div class="container">
+                <div class="header">
+                    <h1>Plan-Up</h1>
+                </div>
+                <div class="content">
+                    <h2>이메일 인증 실패</h2>
+                    <p>
+                        인증에 실패하였습니다.<br>
+                        Plan-Up 앱에서 다시 시도해주세요.
+                    </p>
+                </div>
+                <div class="footer">
+                    <p>* 링크가 만료되었거나 올바르지 않습니다.</p>
+                    <p>* 앱에서 인증 메일을 다시 요청해주세요.</p>
+                </div>
+            </div>
+        </body>
+        </html>
+        """;
     }
 }


### PR DESCRIPTION
## 📌 개요
사용자가 이메일에 포함된 링크를 눌렀을 때 이후에 나올 결과 화면을 추가했습니다. 

## ✅ 기능 설명
- 이메일이 포함된 링크를 눌렀을 때 인증에 성공했다면, 성공 안내 메시지 페이지가 뜨도록 구현
- 인증에 실패했다면, 실패 안내 메시지 페이지가 뜨도록 구현 