### PR TITLE
[REF] goal에 비활성화 버튼 생성 및 리펙토링

### DIFF
--- a/build/resources/main/application.yml
+++ b/build/resources/main/application.yml
@@ -40,10 +40,10 @@ spring:
       port: 6379
       timeout: 3000ms
 
-app:
-  domain: ${APP_DOMAIN}
-  frontend:
-    url: ${APP_FRONTEND_URL}
+#app:
+#  domain: ${APP_DOMAIN}
+#  frontend:
+#    url: ${APP_FRONTEND_URL}
 
 jwt:
   secret: ${JWT_SECRET}

--- a/src/main/java/com/planup/planup/domain/friend/converter/FriendConverter.java
+++ b/src/main/java/com/planup/planup/domain/friend/converter/FriendConverter.java
@@ -17,23 +17,16 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class FriendConverter {
 
-    private final TimerVerificationService timerVerificationService;
-    private final PhotoVerificationRepository photoVerificationRepository;
 
-    public FriendResponseDTO.FriendInfoSummary toFriendSummary(User friend) {
-        // goalCnt: 실제 사용자의 목표 개수
-        int goalCnt = friend.getUserGoals().size();
-        
-        // todayTime: 오늘 타이머 시간 계산 (모든 목표의 합계)
-        LocalTime todayTime = calculateTodayTotalTime(friend);
-
-        // isNewPhotoVerify: 오늘 사진 인증 여부 확인
-        boolean isNewPhotoVerify = checkTodayPhotoVerification(friend);
-        
-        return FriendResponseDTO.FriendInfoSummary
-                .builder()
+    public FriendResponseDTO.FriendInfoSummary toFriendSummary(
+            User friend,
+            int goalCnt,
+            boolean isNewPhotoVerify,
+            LocalTime todayTime
+    ) {
+        return FriendResponseDTO.FriendInfoSummary.builder()
                 .id(friend.getId())
-                .nickname(friend.getNickname()) 
+                .nickname(friend.getNickname())
                 .goalCnt(goalCnt)
                 .todayTime(todayTime)
                 .isNewPhotoVerify(isNewPhotoVerify)
@@ -49,48 +42,17 @@ public class FriendConverter {
                 .build();
     }
 
-    public FriendResponseDTO.FriendSummaryList toFriendSummaryList(List<User> friends) {
-        List<FriendResponseDTO.FriendInfoSummary> summeryList = friends.stream().map(this::toFriendSummary).collect(Collectors.toList());
-        int size = summeryList.size();
-
-        return FriendResponseDTO.FriendSummaryList
-                .builder()
-                .cnt(size)
-                .friendInfoSummaryList(summeryList)
+    public FriendResponseDTO.FriendSummaryList toFriendSummaryList(List<FriendResponseDTO.FriendInfoSummary> items) {
+        return FriendResponseDTO.FriendSummaryList.builder()
+                .cnt(items.size())
+                .friendInfoSummaryList(items)
                 .build();
     }
     
     /**
      * 사용자의 모든 목표에 대한 오늘 타이머 시간을 합계하여 계산
      */
-    private LocalTime calculateTodayTotalTime(User user) {
-        try {
-            // 사용자의 모든 목표에 대해 오늘 타이머 시간을 합계
-            long totalSeconds = user.getUserGoals().stream()
-                    .mapToLong(userGoal -> {
-                        try {
-                            LocalTime goalTime = timerVerificationService.getTodayTotalTime(user.getId(), userGoal.getGoal().getId());
-                            return goalTime.toSecondOfDay();
-                        } catch (Exception e) {
-                            log.warn("사용자 {} 목표 {} 타이머 시간 조회 실패: {}", user.getNickname(), userGoal.getGoal().getId(), e.getMessage());
-                            return 0L;
-                        }
-                    })
-                    .sum();
-            
-            return LocalTime.ofSecondOfDay(totalSeconds);
-        } catch (Exception e) {
-            log.warn("사용자 {} 오늘 타이머 시간 계산 실패: {}", user.getNickname(), e.getMessage());
-            return LocalTime.of(0, 0, 0);
-        }
-    }
 
-    private boolean checkTodayPhotoVerification(User user) {
-        try {
-            return photoVerificationRepository.existsTodayPhotoVerificationByUserId(user.getId());
-        } catch (Exception e) {
-            log.warn("사용자 {} 오늘 사진 인증 조회 실패: {}", user.getNickname(), e.getMessage());
-            return false;
-        }
-    }
+
+
 }

--- a/src/main/java/com/planup/planup/domain/friend/service/FriendService.java
+++ b/src/main/java/com/planup/planup/domain/friend/service/FriendService.java
@@ -2,6 +2,7 @@ package com.planup.planup.domain.friend.service;
 
 import com.planup.planup.domain.friend.dto.FriendResponseDTO;
 import com.planup.planup.domain.friend.dto.BlockedFriendResponseDTO;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -36,4 +37,7 @@ public interface FriendService {
     boolean unblockFriend(Long userId, String friendNickname);
 
     List<FriendResponseDTO.FriendInfoInChallengeCreate> getFrinedListInChallenge(Long userId);
+
+    @Transactional(readOnly = true)
+    void isFriend(Long userId, Long creatorId);
 }

--- a/src/main/java/com/planup/planup/domain/friend/service/FriendServiceImpl.java
+++ b/src/main/java/com/planup/planup/domain/friend/service/FriendServiceImpl.java
@@ -27,7 +27,7 @@ public class FriendServiceImpl implements FriendService {
     private final FriendConverter friendConverter;
 
     @Override
-    @Transactional(readOnly = true) 
+    @Transactional(readOnly = true)
     public List<FriendResponseDTO.FriendSummaryList> getFriendSummeryList(Long userId) {
 
         User user = userService.getUserbyUserId(userId);
@@ -46,17 +46,17 @@ public class FriendServiceImpl implements FriendService {
     @Override
     @Transactional
     public boolean deleteFriend(Long userId, Long friendId) {
-    // 1. userId와 friendId로 Friend 엔티티를 찾는다.
-    // 2. 해당 Friend 엔티티를 삭제한다.
-    // 3. 성공적으로 삭제했으면 true, 아니면 false 반환
+        // 1. userId와 friendId로 Friend 엔티티를 찾는다.
+        // 2. 해당 Friend 엔티티를 삭제한다.
+        // 3. 성공적으로 삭제했으면 true, 아니면 false 반환
 
         List<Friend> friends = friendRepository.findByStatusAndUserIdOrStatusAndFriendIdOrderByCreatedAtDesc(
-            FriendStatus.ACCEPTED, userId, FriendStatus.ACCEPTED, userId);
+                FriendStatus.ACCEPTED, userId, FriendStatus.ACCEPTED, userId);
 
         Friend friend = friends.stream()
-            .filter(f -> (f.getUser().getId().equals(friendId) || f.getFriend().getId().equals(friendId)))
-            .findFirst()
-            .orElse(null);
+                .filter(f -> (f.getUser().getId().equals(friendId) || f.getFriend().getId().equals(friendId)))
+                .findFirst()
+                .orElse(null);
 
         if (friend != null) {
             friendRepository.delete(friend);
@@ -71,12 +71,12 @@ public class FriendServiceImpl implements FriendService {
     public boolean blockFriend(Long userId, Long friendId) {
         // 1. userId와 friendId로 Friend 엔티티를 찾는다.
         List<Friend> friends = friendRepository.findByStatusAndUserIdOrStatusAndFriendIdOrderByCreatedAtDesc(
-            FriendStatus.ACCEPTED, userId, FriendStatus.ACCEPTED, userId);
+                FriendStatus.ACCEPTED, userId, FriendStatus.ACCEPTED, userId);
 
         Friend friend = friends.stream()
-            .filter(f -> (f.getUser().getId().equals(friendId) || f.getFriend().getId().equals(friendId)))
-            .findFirst()
-            .orElse(null);
+                .filter(f -> (f.getUser().getId().equals(friendId) || f.getFriend().getId().equals(friendId)))
+                .findFirst()
+                .orElse(null);
 
         if (friend != null) {
             friend.setStatus(FriendStatus.BLOCKED); // 상태 변경
@@ -92,10 +92,10 @@ public class FriendServiceImpl implements FriendService {
     public boolean reportFriend(Long userId, Long friendId, String reason, boolean block) {
         // 1. Friend 엔티티 찾기 (ACCEPTED 또는 BLOCKED 상태의 친구 관계)
         List<Friend> acceptedFriends = friendRepository.findByStatusAndUserIdOrStatusAndFriendIdOrderByCreatedAtDesc(
-            FriendStatus.ACCEPTED, userId, FriendStatus.ACCEPTED, userId);
+                FriendStatus.ACCEPTED, userId, FriendStatus.ACCEPTED, userId);
 
         List<Friend> blockedFriends = friendRepository.findByStatusAndUserIdOrStatusAndFriendIdOrderByCreatedAtDesc(
-            FriendStatus.BLOCKED, userId, FriendStatus.BLOCKED, userId);
+                FriendStatus.BLOCKED, userId, FriendStatus.BLOCKED, userId);
 
         // 두 리스트 합치기
         List<Friend> allFriends = new ArrayList<>();
@@ -103,9 +103,9 @@ public class FriendServiceImpl implements FriendService {
         allFriends.addAll(blockedFriends);
 
         Friend friend = allFriends.stream()
-            .filter(f -> (f.getUser().getId().equals(friendId) || f.getFriend().getId().equals(friendId)))
-            .findFirst()
-            .orElse(null);
+                .filter(f -> (f.getUser().getId().equals(friendId) || f.getFriend().getId().equals(friendId)))
+                .findFirst()
+                .orElse(null);
 
         if (friend != null) {
             // 신고 사유 저장 (별도 테이블이 있다면 Report 엔티티에 저장, 없다면 로그 등)
@@ -126,7 +126,7 @@ public class FriendServiceImpl implements FriendService {
     @Transactional(readOnly = true)
     public List<FriendResponseDTO.FriendInfoSummary> getRequestedFriends(Long userId) {
         List<Friend> friendRequests = friendRepository.findByStatusAndFriendIdOrderByCreatedAtDesc(
-            FriendStatus.REQUESTED, userId);
+                FriendStatus.REQUESTED, userId);
 
         // 신청한 친구(User) 정보 추출
         // 친구 신청이 없을 때 빈 리스트 반환
@@ -144,12 +144,12 @@ public class FriendServiceImpl implements FriendService {
     public boolean rejectFriendRequest(Long userId, Long friendId) {
         // 나(userId)에게 친구 신청한 친구(friendId)를 찾음
         List<Friend> requests = friendRepository.findByStatusAndFriendIdOrderByCreatedAtDesc(
-            FriendStatus.REQUESTED, userId);
+                FriendStatus.REQUESTED, userId);
 
         Friend friend = requests.stream()
-            .filter(f -> f.getUser().getId().equals(friendId))
-            .findFirst()
-            .orElse(null);
+                .filter(f -> f.getUser().getId().equals(friendId))
+                .findFirst()
+                .orElse(null);
 
         if (friend != null) {
             friendRepository.delete(friend); // 엔티티 삭제
@@ -164,12 +164,12 @@ public class FriendServiceImpl implements FriendService {
     public boolean acceptFriendRequest(Long userId, Long friendId) {
         // 나(userId)에게 친구 신청한 친구(friendId)를 찾음
         List<Friend> requests = friendRepository.findByStatusAndFriendIdOrderByCreatedAtDesc(
-            FriendStatus.REQUESTED, userId);
+                FriendStatus.REQUESTED, userId);
 
         Friend friend = requests.stream()
-            .filter(f -> f.getUser().getId().equals(friendId))
-            .findFirst()
-            .orElse(null);
+                .filter(f -> f.getUser().getId().equals(friendId))
+                .findFirst()
+                .orElse(null);
 
         if (friend != null) {
             friend.setStatus(FriendStatus.ACCEPTED); // 상태를 ACCEPTED로 변경
@@ -185,10 +185,10 @@ public class FriendServiceImpl implements FriendService {
     public boolean sendFriendRequest(Long userId, Long friendId) {
         // 이미 친구 관계가 있는지, 이미 신청했는지 체크(중복 방지)
         List<Friend> existingAccepted = friendRepository.findByStatusAndUserIdOrStatusAndFriendIdOrderByCreatedAtDesc(
-            FriendStatus.ACCEPTED, userId, FriendStatus.ACCEPTED, userId);
+                FriendStatus.ACCEPTED, userId, FriendStatus.ACCEPTED, userId);
 
         List<Friend> existingRequested = friendRepository.findByStatusAndUserIdOrStatusAndFriendIdOrderByCreatedAtDesc(
-            FriendStatus.REQUESTED, userId, FriendStatus.REQUESTED, userId);
+                FriendStatus.REQUESTED, userId, FriendStatus.REQUESTED, userId);
 
         // 두 리스트 합치기
         List<Friend> allExisting = new ArrayList<>();
@@ -196,7 +196,7 @@ public class FriendServiceImpl implements FriendService {
         allExisting.addAll(existingRequested);
 
         boolean alreadyRequested = allExisting.stream()
-            .anyMatch(f -> (f.getUser().getId().equals(friendId) || f.getFriend().getId().equals(friendId)));
+                .anyMatch(f -> (f.getUser().getId().equals(friendId) || f.getFriend().getId().equals(friendId)));
 
         if (alreadyRequested) {
             return false; // 이미 친구거나 신청함
@@ -264,5 +264,23 @@ public class FriendServiceImpl implements FriendService {
 
         // 차단 관계를 찾지 못했을 때
         throw new UserException(ErrorStatus._BAD_REQUEST);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public void isFriend(Long userId, Long creatorId) {
+        List<Friend> friendRelations = friendRepository
+                .findByStatusAndUserIdOrStatusAndFriendIdOrderByCreatedAtDesc(
+                        FriendStatus.ACCEPTED, userId,
+                        FriendStatus.ACCEPTED, userId);
+
+        boolean isFriend = friendRelations.stream()
+                .anyMatch(friend ->
+                        (friend.getUser().getId().equals(creatorId) && friend.getFriend().getId().equals(userId)) ||
+                                (friend.getFriend().getId().equals(creatorId) && friend.getUser().getId().equals(userId))
+                );
+        if (!isFriend) {
+            throw new RuntimeException("친구 관계가 아니므로 목표를 조회할 수 없습니다.");
+        }
     }
 }

--- a/src/main/java/com/planup/planup/domain/friend/service/FriendServiceImpl.java
+++ b/src/main/java/com/planup/planup/domain/friend/service/FriendServiceImpl.java
@@ -8,8 +8,7 @@ import com.planup.planup.domain.friend.repository.FriendRepository;
 import com.planup.planup.domain.user.entity.User;
 import com.planup.planup.domain.user.service.UserService;
 import com.planup.planup.domain.verification.repository.PhotoVerificationRepository;
-import com.planup.planup.domain.verification.service.PhotoVerificationService;
-import com.planup.planup.domain.verification.service.TimerVerificationService;
+import com.planup.planup.domain.verification.service.TimerVerificationReadService;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -32,8 +31,7 @@ public class FriendServiceImpl implements FriendService {
     private final FriendRepository friendRepository;
     private final UserService userService;
     private final FriendConverter friendConverter;
-    private final TimerVerificationService timerVerificationService;
-    private final PhotoVerificationService photoVerificationService;
+    private final TimerVerificationReadService timerVerificationService;
     private final PhotoVerificationRepository photoVerificationRepository;
 
     @Override
@@ -167,7 +165,7 @@ public class FriendServiceImpl implements FriendService {
             long totalSeconds = user.getUserGoals().stream()
                     .mapToLong(userGoal -> {
                         try {
-                            LocalTime goalTime = timerVerificationService.getTodayTotalTime(userGoal.getUser().getId(), userGoal.getGoal().getId());
+                            LocalTime goalTime = timerVerificationService.getTodayTotalTime(userGoal);
                             return goalTime.toSecondOfDay();
                         } catch (Exception e) {
                             log.warn("사용자 {} 목표 {} 타이머 시간 조회 실패: {}", user.getNickname(), userGoal.getGoal().getId(), e.getMessage());

--- a/src/main/java/com/planup/planup/domain/global/scheduler/GoalExpireScheduler.java
+++ b/src/main/java/com/planup/planup/domain/global/scheduler/GoalExpireScheduler.java
@@ -1,0 +1,22 @@
+package com.planup.planup.domain.global.scheduler;
+
+import com.planup.planup.domain.goal.service.GoalLifeService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.Date;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class GoalExpireScheduler {
+
+    private final GoalLifeService goalLifeService;
+
+    @Scheduled(cron = "0 0 0 * * MON", zone = "Asia/Seoul")
+    public void checkExpireGoal() {
+        goalLifeService.disableExpiredGoals(new Date());
+    }
+}

--- a/src/main/java/com/planup/planup/domain/goal/entity/Goal.java
+++ b/src/main/java/com/planup/planup/domain/goal/entity/Goal.java
@@ -18,7 +18,6 @@ import java.util.List;
 @Entity
 @Getter
 @SuperBuilder
-@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @Inheritance(strategy = InheritanceType.JOINED)

--- a/src/main/java/com/planup/planup/domain/goal/entity/Goal.java
+++ b/src/main/java/com/planup/planup/domain/goal/entity/Goal.java
@@ -1,6 +1,7 @@
 package com.planup.planup.domain.goal.entity;
 
 import com.planup.planup.domain.global.entity.BaseTimeEntity;
+import com.planup.planup.domain.goal.dto.GoalRequestDto;
 import com.planup.planup.domain.goal.entity.Enum.GoalCategory;
 import com.planup.planup.domain.goal.entity.Enum.GoalPeriod;
 import com.planup.planup.domain.goal.entity.Enum.GoalType;
@@ -77,5 +78,18 @@ public class Goal extends BaseTimeEntity {
         for (UserGoal userGoal : userGoals) {
             userGoal.setActive(false);
         }
+    }
+
+    public void updateFrom(GoalRequestDto.CreateGoalDto dto) {
+        this.goalName = dto.getGoalName();
+        this.goalAmount = dto.getGoalAmount();
+        this.goalCategory = dto.getGoalCategory();
+        this.goalType = dto.getGoalType();
+        this.oneDose = dto.getOneDose();
+        this.frequency = dto.getFrequency();
+        this.period = dto.getPeriod();
+        this.endDate = dto.getEndDate();
+        this.verificationType = dto.getVerificationType();
+        this.limitFriendCount = dto.getLimitFriendCount();
     }
 }

--- a/src/main/java/com/planup/planup/domain/goal/entity/Goal.java
+++ b/src/main/java/com/planup/planup/domain/goal/entity/Goal.java
@@ -57,6 +57,9 @@ public class Goal extends BaseTimeEntity {
     //종료일
     private Date endDate;
 
+    @Builder.Default
+    private boolean isActive = true;
+
     //목표 인증 방식(타이머/사진)
     @Enumerated(EnumType.STRING)
     @Column(length = 20)
@@ -67,4 +70,12 @@ public class Goal extends BaseTimeEntity {
 
     @OneToMany(mappedBy = "goal", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Comment> commentList = new ArrayList<>();
+
+
+    public void setInActive() {
+        this.isActive = false;
+        for (UserGoal userGoal : userGoals) {
+            userGoal.setActive(false);
+        }
+    }
 }

--- a/src/main/java/com/planup/planup/domain/goal/entity/mapping/UserGoal.java
+++ b/src/main/java/com/planup/planup/domain/goal/entity/mapping/UserGoal.java
@@ -98,4 +98,8 @@ public class UserGoal extends BaseTimeEntity {
         }
         return true;
     }
+
+    public void setGoalTime(int time) {
+        this.goalTime = time;
+    }
 }

--- a/src/main/java/com/planup/planup/domain/goal/entity/mapping/UserGoal.java
+++ b/src/main/java/com/planup/planup/domain/goal/entity/mapping/UserGoal.java
@@ -23,7 +23,6 @@ import java.util.List;
 @Getter
 @SuperBuilder
 @Builder
-@Setter
 @AllArgsConstructor
 @NoArgsConstructor
 public class UserGoal extends BaseTimeEntity {
@@ -79,5 +78,24 @@ public class UserGoal extends BaseTimeEntity {
 
     public void setActive(boolean active) {
         this.setActive(active);
+    }
+
+    public int increaseVerificationCount() {
+        this.verificationCount++;
+        return this.verificationCount;
+    }
+
+    public int decreaseVerificationCount() {
+        if (this.verificationCount > 0) {
+            this.verificationCount--;
+        }
+        return verificationCount;
+    }
+
+    public boolean setPublic() {
+        if (!this.isPublic) {
+            this.isPublic = true;
+        }
+        return true;
     }
 }

--- a/src/main/java/com/planup/planup/domain/goal/entity/mapping/UserGoal.java
+++ b/src/main/java/com/planup/planup/domain/goal/entity/mapping/UserGoal.java
@@ -76,4 +76,8 @@ public class UserGoal extends BaseTimeEntity {
             goal.getUserGoals().add(this);
         }
     }
+
+    public void setActive(boolean active) {
+        this.setActive(active);
+    }
 }

--- a/src/main/java/com/planup/planup/domain/goal/repository/GoalRepository.java
+++ b/src/main/java/com/planup/planup/domain/goal/repository/GoalRepository.java
@@ -4,6 +4,11 @@ import com.planup.planup.domain.goal.entity.Goal;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Date;
+import java.util.List;
+
 @Repository
 public interface GoalRepository extends JpaRepository<Goal, Long> {
+
+    List<Goal> findByEndDateBeforeAndIsActiveTrue(Date now);
 }

--- a/src/main/java/com/planup/planup/domain/goal/repository/UserGoalRepository.java
+++ b/src/main/java/com/planup/planup/domain/goal/repository/UserGoalRepository.java
@@ -24,7 +24,7 @@ public interface UserGoalRepository extends JpaRepository<UserGoal, Long> {
     UserGoal findByGoalIdAndStatus(Long goalId, Status status);
     List<UserGoal> findByGoalId(Long goalId);
 
-    UserGoal findByGoalIdAndUserId(Long goalId, Long userId);
+    Optional<UserGoal> findByGoalIdAndUserId(Long goalId, Long userId);
 
     List<UserGoal> findByUserId(Long userId);
 

--- a/src/main/java/com/planup/planup/domain/goal/service/ChallengeServiceImpl.java
+++ b/src/main/java/com/planup/planup/domain/goal/service/ChallengeServiceImpl.java
@@ -106,17 +106,13 @@ public class ChallengeServiceImpl implements ChallengeService{
         String nickname = first.getUser().getNickname();
 
         if (goal.getGoalType() == GoalType.CHALLENGE_PHOTO) {
-            if (goal instanceof Challenge) {
-                Challenge photoChallenge = (Challenge) goal;
-                ChallengeResponseDTO.ChallengeResponseInfo challengeResponseInfo = ChallengeConverter.toChallengeResponseInfoPhotoVer(photoChallenge, nickname);
-                return challengeResponseInfo;
+            if (goal instanceof Challenge photoChallenge) {
+                return ChallengeConverter.toChallengeResponseInfoPhotoVer(photoChallenge, nickname);
 
             }
         } else if (goal.getGoalType() == GoalType.CHALLENGE_TIME) {
-            if (goal instanceof TimeChallenge) {
-                TimeChallenge timeChallenge = (TimeChallenge) goal;
-                ChallengeResponseDTO.ChallengeResponseInfo challengeResponseInfo = ChallengeConverter.toChallengeResponseInfoTimeVer(timeChallenge);
-                return challengeResponseInfo;
+            if (goal instanceof TimeChallenge timeChallenge) {
+                return ChallengeConverter.toChallengeResponseInfoTimeVer(timeChallenge);
             }
         }
 
@@ -211,6 +207,5 @@ public class ChallengeServiceImpl implements ChallengeService{
             User user = userService.getUserbyUserId(friendId);
             createPerUserGoal(user, type, Status.MEMBER, challenge);
         }
-
     }
 }

--- a/src/main/java/com/planup/planup/domain/goal/service/CommentServiceImpl.java
+++ b/src/main/java/com/planup/planup/domain/goal/service/CommentServiceImpl.java
@@ -27,6 +27,7 @@ public class CommentServiceImpl implements CommentService {
     private final CommentRepository commentRepository;
     private final GoalRepository goalRepository;
     private final UserGoalRepository userGoalRepository;
+    private final UserGoalService userGoalService;
     private final UserService userService;
 
     @Override
@@ -99,7 +100,7 @@ public class CommentServiceImpl implements CommentService {
     }
 
     private void validateUserGoalParticipation(Long goalId, Long userId) {
-        UserGoal userGoal = userGoalRepository.findByGoalIdAndUserId(goalId, userId);
+        UserGoal userGoal = userGoalService.getByGoalIdAndUserId(goalId, userId);
         if (userGoal == null) {
             throw new GoalException(ErrorStatus.UNAUTHORIZED_GOAL_ACCESS);
         }

--- a/src/main/java/com/planup/planup/domain/goal/service/GoalLifeService.java
+++ b/src/main/java/com/planup/planup/domain/goal/service/GoalLifeService.java
@@ -1,0 +1,25 @@
+package com.planup.planup.domain.goal.service;
+
+import com.planup.planup.domain.goal.entity.Goal;
+import com.planup.planup.domain.goal.repository.GoalRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Date;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class GoalLifeService {
+
+    private final GoalRepository goalRepository;
+
+    @Transactional
+    public void disableExpiredGoals(Date date) {
+        List<Goal> goal = goalRepository.findByEndDateBeforeAndIsActiveTrue(date);
+        goal.forEach(Goal::setInActive);
+    }
+}
+
+

--- a/src/main/java/com/planup/planup/domain/goal/service/GoalService.java
+++ b/src/main/java/com/planup/planup/domain/goal/service/GoalService.java
@@ -5,6 +5,7 @@ import com.planup.planup.domain.goal.dto.GoalResponseDto;
 import com.planup.planup.domain.goal.entity.Enum.GoalCategory;
 import com.planup.planup.domain.goal.entity.Goal;
 import com.planup.planup.domain.verification.dto.PhotoVerificationResponseDto;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -16,6 +17,10 @@ public interface GoalService {
     List<GoalResponseDto.GoalCreateListDto> getGoalList(Long userId, GoalCategory goalCategory);
     GoalResponseDto.MyGoalDetailDto getMyGoalDetails(Long goalId, Long userId);
     void updatePublicGoal(Long goalId, Long userId);
+
+    @Transactional
+    Goal findGoalById(Long goalId);
+
     void deleteGoal(Long goalId, Long userId);
     GoalRequestDto.CreateGoalDto getGoalInfoToUpdate(Long goalId, Long userId);
     void updateGoal(Long goalId, Long userId, GoalRequestDto.CreateGoalDto dto);

--- a/src/main/java/com/planup/planup/domain/goal/service/GoalServiceImpl.java
+++ b/src/main/java/com/planup/planup/domain/goal/service/GoalServiceImpl.java
@@ -33,6 +33,7 @@ import java.util.stream.Collectors;
 public class GoalServiceImpl implements GoalService{
     private final GoalRepository goalRepository;
     private final UserGoalRepository userGoalRepository;
+    private final UserGoalService userGoalService;
     private final UserRepository userRepository;
     private final TimerVerificationRepository timerVerificationRepository;
     private final PhotoVerificationRepository photoVerificationRepository;
@@ -139,7 +140,7 @@ public class GoalServiceImpl implements GoalService{
     //내 목표 조회(세부 내용 조회)
     @Transactional(readOnly = true)
     public GoalResponseDto.MyGoalDetailDto getMyGoalDetails(Long goalId, Long userId) {
-        UserGoal userGoal = userGoalRepository.findByGoalIdAndUserId(goalId, userId);
+        UserGoal userGoal = userGoalService.getByGoalIdAndUserId(goalId, userId);
 
         return GoalConvertor.toMyGoalDetailsDto(userGoal);
     }
@@ -147,7 +148,7 @@ public class GoalServiceImpl implements GoalService{
     //활성화/비활성화
     @Transactional
     public void updateActiveGoal(Long goalId, Long userId) {
-        UserGoal userGoal = userGoalRepository.findByGoalIdAndUserId(goalId, userId);
+        UserGoal userGoal = userGoalService.getByGoalIdAndUserId(goalId, userId);
 
         userGoal.setActive(!userGoal.isActive());
     }
@@ -155,7 +156,7 @@ public class GoalServiceImpl implements GoalService{
     //공개/비공개
     @Transactional
     public void updatePublicGoal(Long goalId, Long userId) {
-        UserGoal userGoal = userGoalRepository.findByGoalIdAndUserId(goalId, userId);
+        UserGoal userGoal = userGoalService.getByGoalIdAndUserId(goalId, userId);
         //공개 상태 변경
         userGoal.setPublic();
     }
@@ -167,7 +168,7 @@ public class GoalServiceImpl implements GoalService{
 
         Integer goalTime = null;
         if (goal.getVerificationType() == VerificationType.TIMER) {
-            UserGoal userGoal = userGoalRepository.findByGoalIdAndUserId(goalId, userId);
+            UserGoal userGoal = userGoalService.getByGoalIdAndUserId(goalId, userId);
             if (userGoal != null && !userGoal.getTimerVerifications().isEmpty()) {
                 goalTime = userGoal.getGoalTime();
             }
@@ -183,7 +184,7 @@ public class GoalServiceImpl implements GoalService{
         goal.updateFrom(dto);
 
         if (dto.getVerificationType() == VerificationType.TIMER && dto.getGoalTime() != null) {
-            UserGoal userGoal = userGoalRepository.findByGoalIdAndUserId(goalId, userId);
+            UserGoal userGoal = userGoalService.getByGoalIdAndUserId(goalId, userId);
             if (userGoal != null) {
                 userGoal.setGoalTime(dto.getGoalTime());
             }
@@ -224,7 +225,7 @@ public class GoalServiceImpl implements GoalService{
     //사진 조회
     @Transactional(readOnly = true)
     public List<PhotoVerificationResponseDto.uploadPhotoResponseDto> getGoalPhotos(Long userId, Long goalId) {
-        UserGoal userGoal = userGoalRepository.findByGoalIdAndUserId(goalId, userId);
+        UserGoal userGoal = userGoalService.getByGoalIdAndUserId(goalId, userId);
         if (userGoal == null) {
             throw new RuntimeException("해당 목표를 찾을 수 없거나 접근 권한이 없습니다.");
         }

--- a/src/main/java/com/planup/planup/domain/goal/service/GoalServiceImpl.java
+++ b/src/main/java/com/planup/planup/domain/goal/service/GoalServiceImpl.java
@@ -1,13 +1,9 @@
 package com.planup.planup.domain.goal.service;
 
-import com.planup.planup.domain.friend.entity.Friend;
-import com.planup.planup.domain.friend.entity.FriendStatus;
-import com.planup.planup.domain.friend.repository.FriendRepository;
 import com.planup.planup.domain.friend.service.FriendService;
 import com.planup.planup.domain.goal.convertor.GoalConvertor;
 import com.planup.planup.domain.goal.dto.GoalRequestDto;
 import com.planup.planup.domain.goal.dto.GoalResponseDto;
-import com.planup.planup.domain.goal.entity.Comment;
 import com.planup.planup.domain.goal.entity.Enum.GoalCategory;
 import com.planup.planup.domain.goal.entity.Enum.Status;
 import com.planup.planup.domain.goal.entity.Enum.VerificationType;
@@ -161,14 +157,13 @@ public class GoalServiceImpl implements GoalService{
     public void updatePublicGoal(Long goalId, Long userId) {
         UserGoal userGoal = userGoalRepository.findByGoalIdAndUserId(goalId, userId);
         //공개 상태 변경
-        userGoal.setPublic(!userGoal.isPublic());
+        userGoal.setPublic();
     }
 
     //친구 목표 수정(정보 조회)
     @Transactional(readOnly = true)
     public GoalRequestDto.CreateGoalDto getGoalInfoToUpdate(Long goalId, Long userId) {
-        Goal goal = goalRepository.findById(goalId)
-                .orElseThrow(() -> new RuntimeException("목표를 찾을 수 없습니다."));
+        Goal goal = findGoalById(goalId);
 
         Integer goalTime = null;
         if (goal.getVerificationType() == VerificationType.TIMER) {
@@ -183,8 +178,7 @@ public class GoalServiceImpl implements GoalService{
 
     @Transactional
     public void updateGoal(Long goalId, Long userId, GoalRequestDto.CreateGoalDto dto) {
-        Goal goal = goalRepository.findById(goalId)
-                .orElseThrow(() -> new RuntimeException("목표를 찾을 수 없습니다."));
+        Goal goal = findGoalById(goalId);
 
         goal.updateFrom(dto);
 
@@ -196,12 +190,18 @@ public class GoalServiceImpl implements GoalService{
         }
     }
 
+    @Override
+    @Transactional
+    public Goal findGoalById(Long goalId) {
+        return goalRepository.findById(goalId)
+                .orElseThrow(() -> new RuntimeException("목표를 찾을 수 없습니다."));
+    }
+
 
     //목표 삭제
     @Transactional
     public void deleteGoal(Long goalId, Long userId) {
-        Goal goal = goalRepository.findById(goalId)
-                .orElseThrow(() -> new RuntimeException("목표를 찾을 수 없습니다."));
+        Goal goal = findGoalById(goalId);
 
         UserGoal adminUserGoal = userGoalRepository.findByGoalIdAndStatus(goalId, Status.ADMIN);
         if (adminUserGoal == null) {

--- a/src/main/java/com/planup/planup/domain/goal/service/UserGoalService.java
+++ b/src/main/java/com/planup/planup/domain/goal/service/UserGoalService.java
@@ -16,10 +16,7 @@ public interface UserGoalService {
     UserGoal getUserGoalByUserAndGoal(User user, Goal goal);
     List<UserGoal> getUserGoalListByGoal(Goal goal);
 
-//    List<UserGoal> getUserGoalListByGoalBetweenDay(User user, LocalDateTime startDate, LocalDateTime endDate);
-
     VerificationType checkVerificationType(UserGoal userGoal);
-
 
     //Command Service
     CommunityResponseDto.JoinGoalResponseDto joinGoal(Long userId, Long goalId);

--- a/src/main/java/com/planup/planup/domain/goal/service/UserGoalService.java
+++ b/src/main/java/com/planup/planup/domain/goal/service/UserGoalService.java
@@ -6,6 +6,7 @@ import com.planup.planup.domain.goal.entity.Goal;
 import com.planup.planup.domain.goal.entity.mapping.UserGoal;
 import com.planup.planup.domain.user.entity.User;
 import org.springframework.cglib.core.Local;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -25,4 +26,6 @@ public interface UserGoalService {
 
     List<UserGoal> getUserGoalInPeriod(LocalDateTime startDate, LocalDateTime endDate);
 
+    @Transactional(readOnly = true)
+    UserGoal getByGoalIdAndUserId(Long goalId, Long userId);
 }

--- a/src/main/java/com/planup/planup/domain/goal/service/UserGoalServiceImpl.java
+++ b/src/main/java/com/planup/planup/domain/goal/service/UserGoalServiceImpl.java
@@ -1,10 +1,9 @@
 package com.planup.planup.domain.goal.service;
 
+import com.planup.planup.apiPayload.code.status.ErrorStatus;
+import com.planup.planup.apiPayload.exception.custom.UserGoalException;
 import com.planup.planup.domain.friend.service.FriendService;
 import com.planup.planup.domain.goal.entity.Enum.VerificationType;
-import com.planup.planup.domain.friend.entity.Friend;
-import com.planup.planup.domain.friend.entity.FriendStatus;
-import com.planup.planup.domain.friend.repository.FriendRepository;
 import com.planup.planup.domain.goal.dto.CommunityResponseDto;
 import com.planup.planup.domain.goal.convertor.UserGoalConvertor;
 import com.planup.planup.domain.goal.entity.Enum.GoalType;
@@ -29,6 +28,7 @@ import java.util.List;
 public class UserGoalServiceImpl implements UserGoalService{
 
     private final UserGoalRepository userGoalRepository;
+    private final UserGoalService userGoalService;
     private final GoalRepository goalRepository;
     private final UserRepository userRepository;
     private final FriendService friendService;
@@ -41,7 +41,7 @@ public class UserGoalServiceImpl implements UserGoalService{
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new RuntimeException("존재하지 않는 유저입니다."));
 
-        UserGoal existingUserGoal = userGoalRepository.findByGoalIdAndUserId(goalId, userId);
+        UserGoal existingUserGoal = userGoalService.getByGoalIdAndUserId(goalId, userId);
         if (existingUserGoal != null) {
             throw new RuntimeException("이미 참가한 목표입니다.");
         }
@@ -112,5 +112,11 @@ public class UserGoalServiceImpl implements UserGoalService{
     @Override
     public List<UserGoal> getUserGoalInPeriod(LocalDateTime startDate, LocalDateTime endDate) {
         return userGoalRepository.findAllByUpdatedAtBetween(startDate, endDate);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public UserGoal getByGoalIdAndUserId(Long goalId, Long userId) {
+        return userGoalRepository.findByGoalIdAndUserId(goalId, userId).orElseThrow(() -> new UserGoalException(ErrorStatus.NOT_FOUND_USERGOAL));
     }
 }

--- a/src/main/java/com/planup/planup/domain/goal/service/UserGoalServiceImpl.java
+++ b/src/main/java/com/planup/planup/domain/goal/service/UserGoalServiceImpl.java
@@ -1,5 +1,6 @@
 package com.planup.planup.domain.goal.service;
 
+import com.planup.planup.domain.friend.service.FriendService;
 import com.planup.planup.domain.goal.entity.Enum.VerificationType;
 import com.planup.planup.domain.friend.entity.Friend;
 import com.planup.planup.domain.friend.entity.FriendStatus;
@@ -30,7 +31,7 @@ public class UserGoalServiceImpl implements UserGoalService{
     private final UserGoalRepository userGoalRepository;
     private final GoalRepository goalRepository;
     private final UserRepository userRepository;
-    private final FriendRepository friendRepository;
+    private final FriendService friendService;
 
     @Transactional
     public CommunityResponseDto.JoinGoalResponseDto joinGoal(Long userId, Long goalId) {
@@ -83,18 +84,8 @@ public class UserGoalServiceImpl implements UserGoalService{
 
         Long creatorId = adminUserGoal.getUser().getId();
 
-        List<Friend> friendRelations = friendRepository.findByStatusAndUserIdOrStatusAndFriendIdOrderByCreatedAtDesc(
-                FriendStatus.ACCEPTED, userId, FriendStatus.ACCEPTED, userId);
+        friendService.isFriend(userId, creatorId);
 
-        boolean isFriend = friendRelations.stream()
-                .anyMatch(friend ->
-                        (friend.getUser().getId().equals(creatorId) && friend.getFriend().getId().equals(userId)) ||
-                                (friend.getFriend().getId().equals(creatorId) && friend.getUser().getId().equals(userId))
-                );
-
-        if (!isFriend) {
-            throw new RuntimeException("친구 목표는 친구 관계인 사용자만 참가할 수 있습니다.");
-        }
     }
 
     //수용 형 파트

--- a/src/main/java/com/planup/planup/domain/goal/service/UserGoalServiceImpl.java
+++ b/src/main/java/com/planup/planup/domain/goal/service/UserGoalServiceImpl.java
@@ -28,7 +28,6 @@ import java.util.List;
 public class UserGoalServiceImpl implements UserGoalService{
 
     private final UserGoalRepository userGoalRepository;
-    private final UserGoalService userGoalService;
     private final GoalRepository goalRepository;
     private final UserRepository userRepository;
     private final FriendService friendService;
@@ -41,7 +40,7 @@ public class UserGoalServiceImpl implements UserGoalService{
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new RuntimeException("존재하지 않는 유저입니다."));
 
-        UserGoal existingUserGoal = userGoalService.getByGoalIdAndUserId(goalId, userId);
+        UserGoal existingUserGoal = getByGoalIdAndUserId(goalId, userId);
         if (existingUserGoal != null) {
             throw new RuntimeException("이미 참가한 목표입니다.");
         }

--- a/src/main/java/com/planup/planup/domain/report/service/GoalReportServiceImpl.java
+++ b/src/main/java/com/planup/planup/domain/report/service/GoalReportServiceImpl.java
@@ -17,7 +17,9 @@ import com.planup.planup.domain.report.repository.ReportUserRepository;
 import com.planup.planup.domain.user.entity.User;
 import com.planup.planup.domain.verification.entity.PhotoVerification;
 import com.planup.planup.domain.verification.entity.TimerVerification;
+import com.planup.planup.domain.verification.service.PhotoVerificationReadService;
 import com.planup.planup.domain.verification.service.PhotoVerificationService;
+import com.planup.planup.domain.verification.service.TimerVerificationReadService;
 import com.planup.planup.domain.verification.service.TimerVerificationService;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -37,11 +39,11 @@ public class GoalReportServiceImpl implements GoalReportService {
 
     private final GoalReportRepository goalReportRepository;
     private final UserGoalService userGoalService;
-    private final PhotoVerificationService photoVerificationService;
-    private final TimerVerificationService timerVerificationService;
+    private final TimerVerificationReadService timerVerificationReadService;
     private final RedisServiceForReport redisServiceForReport;
     private final ReportUserRepository reportUserRepository;
     private final AchievementCalculationService achievementCalculationService;
+    private final PhotoVerificationReadService photoVerificationReadService;
 
     @Override
     public void createGoalReportsByUserGoal(LocalDateTime startDate, LocalDateTime endDate) {
@@ -194,9 +196,9 @@ public class GoalReportServiceImpl implements GoalReportService {
 
         //각 케이스에 따라 값을 불러온다
         if (goal.getVerificationType().equals(VerificationType.PHOTO)) {
-            dailyCount = photoVerificationService.calculateVerification(userGoal, startDate, endDate);
+            dailyCount = photoVerificationReadService.calculateVerification(userGoal, startDate, endDate);
         } else if (goal.getVerificationType().equals(VerificationType.TIMER)) {
-            dailyCount = timerVerificationService.calculateVerification(userGoal, startDate, endDate);
+            dailyCount = timerVerificationReadService.calculateVerification(userGoal, startDate, endDate);
         } else {
             throw new RuntimeException();
         }

--- a/src/main/java/com/planup/planup/domain/report/service/WeeklyReportServiceImpl.java
+++ b/src/main/java/com/planup/planup/domain/report/service/WeeklyReportServiceImpl.java
@@ -7,7 +7,6 @@ import com.planup.planup.domain.bedge.entity.BadgeType;
 import com.planup.planup.domain.goal.entity.mapping.UserGoal;
 import com.planup.planup.domain.goal.service.UserGoalService;
 import com.planup.planup.domain.notification.dto.NotificationResponseDTO;
-import com.planup.planup.domain.notification.entity.Notification;
 import com.planup.planup.domain.notification.service.NotificationService;
 import com.planup.planup.domain.report.converter.DailyRecordConverter;
 import com.planup.planup.domain.report.converter.WeeklyReportResponseConverter;

--- a/src/main/java/com/planup/planup/domain/verification/controller/VerificationController.java
+++ b/src/main/java/com/planup/planup/domain/verification/controller/VerificationController.java
@@ -1,9 +1,12 @@
 package com.planup.planup.domain.verification.controller;
 
 import com.planup.planup.apiPayload.ApiResponse;
+import com.planup.planup.domain.goal.entity.mapping.UserGoal;
+import com.planup.planup.domain.goal.service.UserGoalService;
 import com.planup.planup.domain.verification.convertor.TimerVerificationConverter;
 import com.planup.planup.domain.verification.dto.TimerVerificationResponseDto;
 import com.planup.planup.domain.verification.service.PhotoVerificationService;
+import com.planup.planup.domain.verification.service.TimerVerificationReadService;
 import com.planup.planup.domain.verification.service.TimerVerificationService;
 import com.planup.planup.validation.annotation.CurrentUser;
 import com.planup.planup.validation.jwt.JwtUtil;
@@ -21,9 +24,10 @@ import java.time.LocalTime;
 @RequestMapping("/verification")
 public class VerificationController {
 
+    private final TimerVerificationReadService timerVerificationReadService;
     private final TimerVerificationService timerVerificationService;
     private final PhotoVerificationService photoVerificationService;
-    private final JwtUtil jwtUtil;
+    private final UserGoalService userGoalService;
 
     @PostMapping("/timer/start")
     @Operation(summary = "타이머 시작 API", description = "선택한 목표의 타이머 인증을 시작합니다.")
@@ -55,7 +59,9 @@ public class VerificationController {
             @RequestParam("GoalId") Long goalId,
             @Parameter(hidden = true) @CurrentUser Long userId) {
 
-        LocalTime totalTime = timerVerificationService.getTodayTotalTime(userId, goalId);
+
+        UserGoal userGoal = userGoalService.getByGoalIdAndUserId(userId, goalId);
+        LocalTime totalTime = timerVerificationReadService.getTodayTotalTime(userGoal);
 
         TimerVerificationResponseDto.TodayTotalTimeResponseDto result =
                 TimerVerificationConverter.toTodayTotalTimeResponse(totalTime);

--- a/src/main/java/com/planup/planup/domain/verification/service/PhotoVerificationReadService.java
+++ b/src/main/java/com/planup/planup/domain/verification/service/PhotoVerificationReadService.java
@@ -1,0 +1,44 @@
+package com.planup.planup.domain.verification.service;
+
+import com.planup.planup.domain.goal.entity.mapping.UserGoal;
+import com.planup.planup.domain.verification.entity.PhotoVerification;
+import com.planup.planup.domain.verification.repository.PhotoVerificationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Transactional
+@Service
+@RequiredArgsConstructor
+public class PhotoVerificationReadService {
+
+    private final PhotoVerificationRepository photoVerificationRepository;
+
+    @Transactional(readOnly = true)
+    public List<PhotoVerification> getPhotoVerificationListByUserAndDateBetween(UserGoal userGoal, LocalDateTime start, LocalDateTime end) {
+        return photoVerificationRepository.findAllByUserGoalAndCreatedAtBetweenOrderByCreatedAt(userGoal,start,end);
+    }
+
+    @Transactional(readOnly = true)
+    public Map<LocalDate, Integer> calculateVerification(UserGoal userGoal, LocalDateTime startDate, LocalDateTime endDate) {
+        List<PhotoVerification> verifications = getPhotoVerificationListByUserAndDateBetween(userGoal, startDate, endDate);
+
+        Map<LocalDate, Integer> dailyCount = new HashMap<>();
+        // 날짜별 인증 수 카운팅
+        for (PhotoVerification photoVerification : verifications) {
+            LocalDate date = photoVerification.getCreatedAt().toLocalDate();
+
+            int photoCount = photoVerification.getPhotoImgs() != null ? photoVerification.getPhotoImgs().size() : 0;
+
+            //기존에 데이터가 있으면 불러와서 더한다.
+            dailyCount.put(date, dailyCount.getOrDefault(date, 0) + photoCount);
+        }
+        return dailyCount;
+    }
+}

--- a/src/main/java/com/planup/planup/domain/verification/service/PhotoVerificationService.java
+++ b/src/main/java/com/planup/planup/domain/verification/service/PhotoVerificationService.java
@@ -64,26 +64,4 @@ public class PhotoVerificationService implements VerificationService {
 
         photoVerificationRepository.delete(verification);
     }
-
-    @Transactional(readOnly = true)
-    public List<PhotoVerification> getPhotoVerificationListByUserAndDateBetween(UserGoal userGoal, LocalDateTime start, LocalDateTime end) {
-        return photoVerificationRepository.findAllByUserGoalAndCreatedAtBetweenOrderByCreatedAt(userGoal,start,end);
-    }
-
-    @Override
-    public Map<LocalDate, Integer> calculateVerification(UserGoal userGoal, LocalDateTime startDate, LocalDateTime endDate) {
-        List<PhotoVerification> verifications = getPhotoVerificationListByUserAndDateBetween(userGoal, startDate, endDate);
-
-        Map<LocalDate, Integer> dailyCount = new HashMap<>();
-        // 날짜별 인증 수 카운팅
-        for (PhotoVerification photoVerification : verifications) {
-            LocalDate date = photoVerification.getCreatedAt().toLocalDate();
-
-            int photoCount = photoVerification.getPhotoImgs() != null ? photoVerification.getPhotoImgs().size() : 0;
-
-            //기존에 데이터가 있으면 불러와서 더한다.
-            dailyCount.put(date, dailyCount.getOrDefault(date, 0) + photoCount);
-        }
-        return dailyCount;
-    }
 }

--- a/src/main/java/com/planup/planup/domain/verification/service/PhotoVerificationService.java
+++ b/src/main/java/com/planup/planup/domain/verification/service/PhotoVerificationService.java
@@ -41,7 +41,7 @@ public class PhotoVerificationService implements VerificationService {
 
         PhotoVerification savedVerification = photoVerificationRepository.save(photoVerification);
 
-        userGoal.setVerificationCount(userGoal.getVerificationCount() + 1);
+        userGoal.increaseVerificationCount();
         userGoalRepository.save(userGoal);
     }
 
@@ -56,7 +56,7 @@ public class PhotoVerificationService implements VerificationService {
 
         UserGoal userGoal = verification.getUserGoal();
         if (userGoal.getVerificationCount() > 0) {
-            userGoal.setVerificationCount(userGoal.getVerificationCount() - 1);
+            userGoal.decreaseVerificationCount();
             userGoalRepository.save(userGoal);
         }
 

--- a/src/main/java/com/planup/planup/domain/verification/service/PhotoVerificationService.java
+++ b/src/main/java/com/planup/planup/domain/verification/service/PhotoVerificationService.java
@@ -3,6 +3,7 @@ package com.planup.planup.domain.verification.service;
 import com.planup.planup.domain.global.service.ImageUploadService;
 import com.planup.planup.domain.goal.entity.mapping.UserGoal;
 import com.planup.planup.domain.goal.repository.UserGoalRepository;
+import com.planup.planup.domain.goal.service.UserGoalService;
 import com.planup.planup.domain.verification.entity.PhotoVerification;
 import com.planup.planup.domain.verification.repository.PhotoVerificationRepository;
 import lombok.RequiredArgsConstructor;
@@ -23,6 +24,7 @@ public class PhotoVerificationService implements VerificationService {
     private final UserGoalRepository userGoalRepository;
     private final PhotoVerificationRepository photoVerificationRepository;
     private final ImageUploadService imageUploadService;
+    private final UserGoalService userGoalService;
 
     @Transactional
     public void uploadPhotoVerification(
@@ -30,7 +32,7 @@ public class PhotoVerificationService implements VerificationService {
             Long goalId,
             MultipartFile photoFile) {
 
-        UserGoal userGoal = userGoalRepository.findByGoalIdAndUserId(goalId, userId);
+        UserGoal userGoal = userGoalService.getByGoalIdAndUserId(goalId, userId);
 
         String photoUrl = imageUploadService.uploadImage(photoFile, "verifications/photos");
 

--- a/src/main/java/com/planup/planup/domain/verification/service/TimerVerificationReadService.java
+++ b/src/main/java/com/planup/planup/domain/verification/service/TimerVerificationReadService.java
@@ -1,0 +1,45 @@
+package com.planup.planup.domain.verification.service;
+
+
+import com.planup.planup.domain.goal.entity.mapping.UserGoal;
+import com.planup.planup.domain.verification.entity.TimerVerification;
+import com.planup.planup.domain.verification.repository.TimerVerificationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Transactional
+@Service
+@RequiredArgsConstructor
+public class TimerVerificationReadService {
+
+    private final TimerVerificationRepository timerVerificationRepository;
+
+    @Transactional(readOnly = true)
+    public List<TimerVerification> getTimerVerificationListByUserAndDateBetween(UserGoal userGoal, LocalDateTime start, LocalDateTime end) {
+        return timerVerificationRepository.findAllByUserGoalAndCreatedAtBetweenOrderByCreatedAt(userGoal, start, end);
+    }
+
+
+    @Transactional(readOnly = true)
+    public Map<LocalDate, Integer> calculateVerification(UserGoal userGoal, LocalDateTime startDate, LocalDateTime endDate) {
+        List<TimerVerification> verifications = getTimerVerificationListByUserAndDateBetween(userGoal, startDate, endDate);
+
+        Map<LocalDate, Integer> dailyCount = new HashMap<>();
+
+        for (TimerVerification verification : verifications) {
+            LocalDate date = verification.getCreatedAt().toLocalDate();
+
+            int seconds = (int) (verification.getSpentTime() != null ? verification.getSpentTime().toMillis() / 1000.0 : 0.0);
+
+            dailyCount.put(date, dailyCount.getOrDefault(date, 0) + seconds);
+        }
+        return dailyCount;
+    }
+}

--- a/src/main/java/com/planup/planup/domain/verification/service/TimerVerificationReadService.java
+++ b/src/main/java/com/planup/planup/domain/verification/service/TimerVerificationReadService.java
@@ -8,11 +8,14 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 @Transactional
 @Service
@@ -41,5 +44,29 @@ public class TimerVerificationReadService {
             dailyCount.put(date, dailyCount.getOrDefault(date, 0) + seconds);
         }
         return dailyCount;
+    }
+
+    //오늘 총 기록시간 조회
+    public LocalTime getTodayTotalTime(UserGoal userGoal) {
+        if (userGoal == null) {
+            return LocalTime.of(0, 0, 0);
+        }
+        List<TimerVerification> todayVerifications = timerVerificationRepository
+                .findTodayVerificationsByUserGoalId(userGoal.getId());
+
+        if (todayVerifications.isEmpty()) {
+            return LocalTime.of(0, 0, 0);
+        }
+
+        Duration total = todayVerifications.stream()
+                .map(TimerVerification::getSpentTime)
+                .filter(Objects::nonNull)
+                .reduce(Duration.ZERO, Duration::plus);
+
+        return LocalTime.of(
+                (int) total.toHours(),
+                (int) (total.toMinutes() % 60),
+                (int) (total.getSeconds() % 60)
+        );
     }
 }

--- a/src/main/java/com/planup/planup/domain/verification/service/TimerVerificationService.java
+++ b/src/main/java/com/planup/planup/domain/verification/service/TimerVerificationService.java
@@ -17,6 +17,7 @@ import java.time.LocalTime;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 @Service
 @RequiredArgsConstructor
@@ -39,7 +40,7 @@ public class TimerVerificationService implements VerificationService{
 
         Duration total = todayVerifications.stream()
                 .map(TimerVerification::getSpentTime)
-                .filter(spentTime -> spentTime != null)
+                .filter(Objects::nonNull)
                 .reduce(Duration.ZERO, Duration::plus);
 
         return LocalTime.of(

--- a/src/main/java/com/planup/planup/domain/verification/service/TimerVerificationService.java
+++ b/src/main/java/com/planup/planup/domain/verification/service/TimerVerificationService.java
@@ -1,6 +1,7 @@
 package com.planup.planup.domain.verification.service;
 
 import com.planup.planup.domain.goal.entity.mapping.UserGoal;
+import com.planup.planup.domain.goal.service.UserGoalService;
 import com.planup.planup.domain.verification.convertor.TimerVerificationConverter;
 import com.planup.planup.domain.verification.repository.TimerVerificationRepository;
 import com.planup.planup.domain.verification.dto.TimerVerificationResponseDto;
@@ -23,11 +24,12 @@ import java.util.Objects;
 @RequiredArgsConstructor
 public class TimerVerificationService implements VerificationService{
     private final UserGoalRepository userGoalRepository;
+    private final UserGoalService userGoalService;
     private final TimerVerificationRepository timerVerificationRepository;
 
     //오늘 총 기록시간 조회
     public LocalTime getTodayTotalTime(Long userId, Long goalId) {
-        UserGoal userGoal = userGoalRepository.findByGoalIdAndUserId(goalId,userId);
+        UserGoal userGoal = userGoalService.getByGoalIdAndUserId(goalId,userId);
         if (userGoal == null) {
             return LocalTime.of(0, 0, 0);
         }
@@ -52,7 +54,7 @@ public class TimerVerificationService implements VerificationService{
 
     //타이머 시작 -> DB 레코드 생성(TimerVerification)
     public TimerVerificationResponseDto.TimerStartResponseDto startTimer(Long userId, Long goalId) {
-        UserGoal userGoal = userGoalRepository.findByGoalIdAndUserId(goalId, userId);
+        UserGoal userGoal = userGoalService.getByGoalIdAndUserId(goalId, userId);
         //에러 처리 필요
 
         List<TimerVerification> runningTimers = timerVerificationRepository

--- a/src/main/java/com/planup/planup/domain/verification/service/TimerVerificationService.java
+++ b/src/main/java/com/planup/planup/domain/verification/service/TimerVerificationService.java
@@ -27,30 +27,6 @@ public class TimerVerificationService implements VerificationService{
     private final UserGoalService userGoalService;
     private final TimerVerificationRepository timerVerificationRepository;
 
-    //오늘 총 기록시간 조회
-    public LocalTime getTodayTotalTime(Long userId, Long goalId) {
-        UserGoal userGoal = userGoalService.getByGoalIdAndUserId(goalId,userId);
-        if (userGoal == null) {
-            return LocalTime.of(0, 0, 0);
-        }
-        List<TimerVerification> todayVerifications = timerVerificationRepository
-                .findTodayVerificationsByUserGoalId(userGoal.getId());
-
-        if (todayVerifications.isEmpty()) {
-            return LocalTime.of(0, 0, 0);
-        }
-
-        Duration total = todayVerifications.stream()
-                .map(TimerVerification::getSpentTime)
-                .filter(Objects::nonNull)
-                .reduce(Duration.ZERO, Duration::plus);
-
-        return LocalTime.of(
-                (int) total.toHours(),
-                (int) (total.toMinutes() % 60),
-                (int) (total.getSeconds() % 60)
-        );
-    }
 
     //타이머 시작 -> DB 레코드 생성(TimerVerification)
     public TimerVerificationResponseDto.TimerStartResponseDto startTimer(Long userId, Long goalId) {

--- a/src/main/java/com/planup/planup/domain/verification/service/TimerVerificationService.java
+++ b/src/main/java/com/planup/planup/domain/verification/service/TimerVerificationService.java
@@ -119,25 +119,5 @@ public class TimerVerificationService implements VerificationService{
         return spentTime.toMinutes() >= goalTimeMinutes;
     }
 
-    @Transactional(readOnly = true)
-    public List<TimerVerification> getTimerVerificationListByUserAndDateBetween(UserGoal userGoal, LocalDateTime start, LocalDateTime end) {
-        return timerVerificationRepository.findAllByUserGoalAndCreatedAtBetweenOrderByCreatedAt(userGoal, start, end);
-    }
 
-    @Override
-    @Transactional
-    public Map<LocalDate, Integer> calculateVerification(UserGoal userGoal, LocalDateTime startDate, LocalDateTime endDate) {
-        List<TimerVerification> verifications = getTimerVerificationListByUserAndDateBetween(userGoal, startDate, endDate);
-
-        Map<LocalDate, Integer> dailyCount = new HashMap<>();
-
-        for (TimerVerification verification : verifications) {
-            LocalDate date = verification.getCreatedAt().toLocalDate();
-
-            int seconds = (int) (verification.getSpentTime() != null ? verification.getSpentTime().toMillis() / 1000.0 : 0.0);
-
-            dailyCount.put(date, dailyCount.getOrDefault(date, 0) + seconds);
-        }
-        return dailyCount;
-    }
 }

--- a/src/main/java/com/planup/planup/domain/verification/service/TimerVerificationService.java
+++ b/src/main/java/com/planup/planup/domain/verification/service/TimerVerificationService.java
@@ -98,7 +98,7 @@ public class TimerVerificationService implements VerificationService{
 
         //인증 횟수 증가
         if (achieved) { //achieved == true
-            userGoal.setVerificationCount(userGoal.getVerificationCount() + 1);
+            userGoal.increaseVerificationCount();
             userGoalRepository.save(userGoal);
         }
 

--- a/src/main/java/com/planup/planup/domain/verification/service/VerificationService.java
+++ b/src/main/java/com/planup/planup/domain/verification/service/VerificationService.java
@@ -8,6 +8,6 @@ import java.time.LocalDateTime;
 import java.util.Map;
 
 public interface VerificationService {
-    @Transactional
-    Map<LocalDate, Integer> calculateVerification(UserGoal userGoal, LocalDateTime startDate, LocalDateTime endDate);
+//    @Transactional
+//    Map<LocalDate, Integer> calculateVerification(UserGoal userGoal, LocalDateTime startDate, LocalDateTime endDate);
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -40,10 +40,10 @@ spring:
       port: 6379
       timeout: 3000ms
 
-app:
-  domain: ${APP_DOMAIN}
-  frontend:
-    url: ${APP_FRONTEND_URL}
+#app:
+#  domain: ${APP_DOMAIN}
+#  frontend:
+#    url: ${APP_FRONTEND_URL}
 
 jwt:
   secret: ${JWT_SECRET}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -40,10 +40,10 @@ spring:
       port: 6379
       timeout: 3000ms
 
-#app:
-#  domain: ${APP_DOMAIN}
-#  frontend:
-#    url: ${APP_FRONTEND_URL}
+app:
+  domain: ${APP_DOMAIN}
+  frontend:
+    url: ${APP_FRONTEND_URL}
 
 jwt:
   secret: ${JWT_SECRET}


### PR DESCRIPTION
\## 🚀 관련 이슈
<!-- 이슈 번호를 작성하여 종료시켜주세요 -->
- close #85 //

## 🔑 주요 변경사항
<!-- 내가 작업한 내용에 대해 작성해주세요! -->
- Goal에 비활성화 필드 추가
- Goal에 비활성화 하는 로직 추가: 자동으로 userGoal도 전부 비활성화로 변경
- Goal에서 Setter 제거: 별도의 set 메서드 생성하여 사용
- GoalService, UserGoalService에서 중복으로 사용하는 친구 여부 확인 메서드는 friendService로 옮겨서 한 번에 처리
- 한 도메인의 서비스 계층은 다른 도메인의 서비스 계층만 접근하도록 수정
- 서비스 계층의 순환 참조 문제를 피하기 위해 Verification 서비스 계층을 읽기/쓰기 두 개로 분리
- friendConverter에서 컨버터 기능만 남기고 다른 데이터 조회/가공은 서비스 계층으로 이동

## ✔️ 체크 리스트
- [ ] Merge 하려는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [ ] 작업한 API에 대해 적절한 **예외처리**가 이루어졌는가?
- [ ] 작업한 API에 대해 적절한 **로그 메시지**가 작성되었는가? (`Controller`나 `Service`에서 `log.error` 활용)
- [ ] Merge 하려는 PR 및 Commit들을 **로컬**에서 실행했을 때 에러가 발생하지 않았는가?

## ↗️ 개선 사항
<!-- 작업한 내용에 대해 좀 더 개선해야할 부분을 작성해주세요! -->

## 📔 참고 자료
- 선택 사항
