### PR TITLE
[FIX] 로그인 시 이메일 중복 문제 해결

### DIFF
--- a/src/main/java/com/planup/planup/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/planup/planup/domain/user/repository/UserRepository.java
@@ -1,6 +1,7 @@
 package com.planup.planup.domain.user.repository;
 
 import com.planup.planup.domain.user.entity.User;
+import com.planup.planup.domain.user.entity.UserActivate;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -13,4 +14,8 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email);
 
     boolean existsByEmail(String email);
+
+    Optional<User> findByEmailAndUserActivate(String email, UserActivate userActivate);
+
+    boolean existsByEmailAndUserActivate(String email, UserActivate userActivate);
 }


### PR DESCRIPTION
## 📌 개요
로그인 시 이메일 중복으로 인한 Query did not return a unique result: 2 results were returned 에러를 해결했습니다.

## ✅ 기능 설명
발생한 문제: 로그인 시 동일 이메일의 다른 상태 계정들로 인한 충돌

해결:
- 동일 이메일의 ACTIVE 상태 사용자만 조회하도록 로직 수정
- Repository에 findByEmailAndUserActivate() 메서드 추가
- 로그인/회원가입/이메일 수정 시 ACTIVE 상태만 대상으로 처리


