### PR TITLE
[FEAT] 프로필 설정 시 랜덤 닉네임 제공 API 구현 

### DIFF
--- a/src/main/java/com/planup/planup/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/planup/planup/apiPayload/code/status/ErrorStatus.java
@@ -78,6 +78,9 @@ public enum ErrorStatus implements BaseErrorCode {
 
     // Goal 관련 에러
     NOT_FOUND_GOAL(HttpStatus.NOT_FOUND, "GOAL4001", "존재하지 않는 목표입니다."),
+
+    // 랜덤 닉네임 관련 에러
+    NICKNAME_DATA_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "NICKNAME5001", "닉네임 생성에 필요한 데이터가 없습니다."),
   ;
 
 

--- a/src/main/java/com/planup/planup/domain/user/controller/UserController.java
+++ b/src/main/java/com/planup/planup/domain/user/controller/UserController.java
@@ -7,6 +7,7 @@ import com.planup.planup.domain.user.converter.UserConverter;
 import com.planup.planup.domain.user.dto.*;
 import com.planup.planup.domain.user.entity.User;
 import com.planup.planup.domain.user.service.EmailService;
+import com.planup.planup.domain.user.service.RandomNicknameService;
 import com.planup.planup.domain.user.service.UserService;
 import com.planup.planup.validation.annotation.CurrentUser;
 import io.swagger.v3.oas.annotations.Operation;
@@ -29,6 +30,7 @@ public class UserController {
     private final UserService userService;
     private final EmailService emailService;
     private final UserConverter userConverter;
+    private final RandomNicknameService randomNicknameService;
 
     @Value("${app.frontend.url:http://localhost:3000}")
     private String frontendUrl;
@@ -240,6 +242,13 @@ public class UserController {
     @PostMapping("/users/auth/email/alternative")
     public ApiResponse<KakaoAuthResponseDTO> emailAuthAlternative(@Valid @RequestBody KakaoAuthRequestDTO request) {
         KakaoAuthResponseDTO result = userService.kakaoAuth(request);
+        return ApiResponse.onSuccess(result);
+    }
+
+    @Operation(summary = "랜덤 닉네임 생성", description = "형용사+명사 조합으로 랜덤 닉네임을 생성합니다")
+    @GetMapping("/profile/nickname/random")
+    public ApiResponse<RandomNicknameResponseDTO> generateRandomNickname() {
+        RandomNicknameResponseDTO result = randomNicknameService.generateRandomNickname();
         return ApiResponse.onSuccess(result);
     }
 }

--- a/src/main/java/com/planup/planup/domain/user/dto/RandomNicknameResponseDTO.java
+++ b/src/main/java/com/planup/planup/domain/user/dto/RandomNicknameResponseDTO.java
@@ -14,10 +14,4 @@ public class RandomNicknameResponseDTO {
 
     @Schema(description = "랜덤 닉네임", example = "행복한고양이")
     private String nickname;
-
-    @Schema(description = "형용사", example = "행복한")
-    private String adjective;
-
-    @Schema(description = "명사", example = "고양이")
-    private String noun;
 }

--- a/src/main/java/com/planup/planup/domain/user/dto/RandomNicknameResponseDTO.java
+++ b/src/main/java/com/planup/planup/domain/user/dto/RandomNicknameResponseDTO.java
@@ -1,0 +1,23 @@
+package com.planup.planup.domain.user.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class RandomNicknameResponseDTO {
+
+    @Schema(description = "랜덤 닉네임", example = "행복한고양이")
+    private String nickname;
+
+    @Schema(description = "형용사", example = "행복한")
+    private String adjective;
+
+    @Schema(description = "명사", example = "고양이")
+    private String noun;
+}

--- a/src/main/java/com/planup/planup/domain/user/entity/Adjective.java
+++ b/src/main/java/com/planup/planup/domain/user/entity/Adjective.java
@@ -1,0 +1,26 @@
+package com.planup.planup.domain.user.entity;
+
+import com.planup.planup.domain.global.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Entity
+@Table(name = "adjective")
+@Getter
+@SuperBuilder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Adjective extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true, length = 20)
+    private String word;
+
+
+}

--- a/src/main/java/com/planup/planup/domain/user/entity/Noun.java
+++ b/src/main/java/com/planup/planup/domain/user/entity/Noun.java
@@ -1,0 +1,26 @@
+package com.planup.planup.domain.user.entity;
+
+import com.planup.planup.domain.global.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Entity
+@Table(name = "noun")
+@Getter
+@SuperBuilder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Noun extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true, length = 20)
+    private String word;
+
+
+}

--- a/src/main/java/com/planup/planup/domain/user/entity/RandomNickname.java
+++ b/src/main/java/com/planup/planup/domain/user/entity/RandomNickname.java
@@ -1,0 +1,25 @@
+package com.planup.planup.domain.user.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class RandomNickname {
+
+    private String adjective;
+    private String noun;
+    private String fullNickname;
+
+    public static RandomNickname of(String adjective, String noun) {
+        return RandomNickname.builder()
+                .adjective(adjective)
+                .noun(noun)
+                .fullNickname(adjective + noun)
+                .build();
+    }
+}

--- a/src/main/java/com/planup/planup/domain/user/repository/AdjectiveRepository.java
+++ b/src/main/java/com/planup/planup/domain/user/repository/AdjectiveRepository.java
@@ -1,0 +1,9 @@
+package com.planup.planup.domain.user.repository;
+
+import com.planup.planup.domain.user.entity.Adjective;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface AdjectiveRepository extends JpaRepository<Adjective, Long> {
+}

--- a/src/main/java/com/planup/planup/domain/user/repository/NounRepository.java
+++ b/src/main/java/com/planup/planup/domain/user/repository/NounRepository.java
@@ -1,0 +1,9 @@
+package com.planup.planup.domain.user.repository;
+
+import com.planup.planup.domain.user.entity.Noun;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface NounRepository extends JpaRepository<Noun, Long> {
+}

--- a/src/main/java/com/planup/planup/domain/user/service/RandomNicknameService.java
+++ b/src/main/java/com/planup/planup/domain/user/service/RandomNicknameService.java
@@ -1,0 +1,8 @@
+package com.planup.planup.domain.user.service;
+
+import com.planup.planup.domain.user.dto.RandomNicknameResponseDTO;
+
+public interface RandomNicknameService {
+    // 랜덤 닉네임 생성
+    RandomNicknameResponseDTO generateRandomNickname();
+}

--- a/src/main/java/com/planup/planup/domain/user/service/RandomNicknameServiceImpl.java
+++ b/src/main/java/com/planup/planup/domain/user/service/RandomNicknameServiceImpl.java
@@ -42,8 +42,6 @@ public class RandomNicknameServiceImpl implements RandomNicknameService {
         
         return RandomNicknameResponseDTO.builder()
                 .nickname(randomNickname.getFullNickname())
-                .adjective(randomNickname.getAdjective())
-                .noun(randomNickname.getNoun())
                 .build();
     }
 

--- a/src/main/java/com/planup/planup/domain/user/service/RandomNicknameServiceImpl.java
+++ b/src/main/java/com/planup/planup/domain/user/service/RandomNicknameServiceImpl.java
@@ -1,0 +1,74 @@
+package com.planup.planup.domain.user.service;
+
+import com.planup.planup.apiPayload.code.status.ErrorStatus;
+import com.planup.planup.apiPayload.exception.custom.UserException;
+import com.planup.planup.domain.user.dto.RandomNicknameResponseDTO;
+import com.planup.planup.domain.user.entity.Adjective;
+import com.planup.planup.domain.user.entity.Noun;
+import com.planup.planup.domain.user.entity.RandomNickname;
+import com.planup.planup.domain.user.repository.AdjectiveRepository;
+import com.planup.planup.domain.user.repository.NounRepository;
+import com.planup.planup.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Random;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class RandomNicknameServiceImpl implements RandomNicknameService {
+
+    private final AdjectiveRepository adjectiveRepository;
+    private final NounRepository nounRepository;
+    private final UserRepository userRepository;
+    private final Random random = new Random();
+
+    @Override
+    public RandomNicknameResponseDTO generateRandomNickname() {
+        List<Adjective> adjectives = adjectiveRepository.findAll();
+        List<Noun> nouns = nounRepository.findAll();
+
+        if (adjectives.isEmpty() || nouns.isEmpty()) {
+            log.error("형용사 또는 명사 데이터가 없습니다. adjectives: {}, nouns: {}", adjectives.size(), nouns.size());
+            throw new UserException(ErrorStatus.NICKNAME_DATA_NOT_FOUND);
+        }
+
+        RandomNickname randomNickname = generateNickname(adjectives, nouns);
+        
+        return RandomNicknameResponseDTO.builder()
+                .nickname(randomNickname.getFullNickname())
+                .adjective(randomNickname.getAdjective())
+                .noun(randomNickname.getNoun())
+                .build();
+    }
+
+    private RandomNickname generateNickname(List<Adjective> adjectives, List<Noun> nouns) {
+        int maxAttempts = 10; // 중복 방지를 위한 최대 시도 횟수
+        
+        for (int attempt = 0; attempt < maxAttempts; attempt++) {
+            Adjective adjective = adjectives.get(random.nextInt(adjectives.size()));
+            Noun noun = nouns.get(random.nextInt(nouns.size()));
+            
+            String fullNickname = adjective.getWord() + noun.getWord();
+            
+            // 닉네임 길이 체크 (20자 이내)
+            if (fullNickname.length() > 20) {
+                continue;
+            }
+            
+            // 중복 체크
+            if (!userRepository.existsByNickname(fullNickname)) {
+                return RandomNickname.of(adjective.getWord(), noun.getWord());
+            }
+        }
+        
+        // 모든 시도 후에도 중복이면 기본 닉네임 반환
+        log.warn("랜덤 닉네임 생성 중 중복이 많아 기본 닉네임을 반환합니다.");
+        return RandomNickname.of("행복한", "사용자");
+    }
+}


### PR DESCRIPTION
## 🚀 관련 이슈
close #99 

## 📌 개요
프로필 설정 시 랜덤 닉네임 제공하는 API를 구현하였습니다. 

## ✅ 기능 설명
- '형용사 + 명사' 조합의 랜덤 닉네임 제공
- 기존 유저들의 닉네임과 중복 확인
- 20자 이내 길이 제한
- 최대 10회 재시도로 중복 방지


