### PR TITLE
Fix: 인증 성공여부 관련 에러 해결

### DIFF
--- a/src/main/java/com/planup/planup/domain/user/controller/UserController.java
+++ b/src/main/java/com/planup/planup/domain/user/controller/UserController.java
@@ -14,6 +14,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
@@ -25,6 +26,7 @@ import java.nio.charset.StandardCharsets;
 
 @RestController
 @RequiredArgsConstructor
+@Slf4j
 public class UserController {
 
     private final UserService userService;
@@ -210,6 +212,14 @@ public class UserController {
                     .body(html);
 
         } catch (IllegalArgumentException e) {
+            log.error("이메일 인증 실패 - 토큰: {}, 오류: {}", token, e.getMessage());
+            String html = emailService.createFailureHtml();
+
+            return ResponseEntity.ok()
+                    .header(HttpHeaders.CONTENT_TYPE, MediaType.TEXT_HTML_VALUE + ";charset=UTF-8")
+                    .body(html);
+        } catch (Exception e) {
+            log.error("이메일 인증 처리 중 예상치 못한 오류 - 토큰: {}, 오류: {}", token, e.getMessage());
             String html = emailService.createFailureHtml();
 
             return ResponseEntity.ok()


### PR DESCRIPTION
## 📌 개요
이메일 인증 성공했지만 웹 페이지에서 "인증 실패" 표시가 뜨는 문제 해결

## ✅ 기능 설명
- 문제: 딥링크 URL에 포함된 `%40`이 `String.format()`의 포맷 지정자로 인식되어 Format specifier '%s' 오류 발생
- 해결: `formatted(deepLinkUrl)`을 `formatted(deepLinkUrl, deepLinkUrl)`로 변경하여 JavaScript의 두 개 `%s` 플레이스홀더에 각각 딥링크 URL 전달


