### PR TITLE
[FIX] OAuthAccount ID 생성 전략 수정

### DIFF
--- a/src/main/java/com/planup/planup/domain/oauth/entity/OAuthAccount.java
+++ b/src/main/java/com/planup/planup/domain/oauth/entity/OAuthAccount.java
@@ -15,7 +15,7 @@ import lombok.experimental.SuperBuilder;
 @AllArgsConstructor
 public class OAuthAccount extends BaseTimeEntity {
 
-    @Id @GeneratedValue
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @Enumerated(EnumType.STRING)


### PR DESCRIPTION
## 📌 개요
OAuthAccount ID 생성 시 시퀀스 초기화 오류 해결

## ✅ 기능 설명

JPA ID 생성 전략을 SEQUENCE에서 IDENTITY로 수정

