### PR TITLE
[FEAT] 목표 달성률 api 추가

### DIFF
--- a/src/main/java/com/planup/planup/domain/goal/controller/GoalController.java
+++ b/src/main/java/com/planup/planup/domain/goal/controller/GoalController.java
@@ -1,6 +1,7 @@
 package com.planup.planup.domain.goal.controller;
 
 import com.planup.planup.apiPayload.ApiResponse;
+import com.planup.planup.domain.friend.service.FriendService;
 import com.planup.planup.domain.goal.dto.CommentRequestDto;
 import com.planup.planup.domain.goal.dto.CommentResponseDto;
 import com.planup.planup.domain.goal.dto.GoalRequestDto;
@@ -8,6 +9,8 @@ import com.planup.planup.domain.goal.dto.GoalResponseDto;
 import com.planup.planup.domain.goal.entity.Enum.GoalCategory;
 import com.planup.planup.domain.goal.service.CommentService;
 import com.planup.planup.domain.goal.service.GoalService;
+import com.planup.planup.domain.user.entity.User;
+import com.planup.planup.domain.user.service.UserService;
 import com.planup.planup.domain.verification.dto.PhotoVerificationResponseDto;
 import com.planup.planup.validation.annotation.CurrentUser;
 import io.swagger.v3.oas.annotations.Operation;
@@ -26,6 +29,8 @@ import java.util.List;
 public class GoalController {
     private final GoalService goalService;
     private final CommentService commentService;
+    private final UserService userService;
+    private final FriendService friendService;
 
     @PostMapping("/create")
     @Operation(summary = "목표 생성 API", description = "목표를 생성하는 API입니다.")
@@ -161,6 +166,22 @@ public class GoalController {
             @Parameter(hidden = true) @CurrentUser Long userId) {
 
         List<PhotoVerificationResponseDto.uploadPhotoResponseDto> result = goalService.getGoalPhotos(userId, goalId);
+
+        return ApiResponse.onSuccess(result);
+    }
+
+    //친구 목표 업로드 사진 조회
+    @GetMapping("/friend/{friendId}/goal/{goalId}/photos")
+    @Operation(summary = "친구 목표 인증 사진 조회 API", description = "친구의 특정 목표에 업로드한 인증 사진들을 조회합니다.")
+    public ApiResponse<List<PhotoVerificationResponseDto.uploadPhotoResponseDto>> getFriendGoalPhotos(
+            @PathVariable Long friendId,
+            @PathVariable Long goalId,
+            @CurrentUser Long userId) {
+        User user = userService.getUserbyUserId(userId);
+        friendService.isFriend(userId, friendId);
+
+        List<PhotoVerificationResponseDto.uploadPhotoResponseDto> result =
+                goalService.getGoalPhotos(friendId, goalId);
 
         return ApiResponse.onSuccess(result);
     }

--- a/src/main/java/com/planup/planup/domain/goal/controller/UserGoalController.java
+++ b/src/main/java/com/planup/planup/domain/goal/controller/UserGoalController.java
@@ -1,6 +1,7 @@
 package com.planup.planup.domain.goal.controller;
 
 import com.planup.planup.apiPayload.ApiResponse;
+import com.planup.planup.domain.friend.service.FriendService;
 import com.planup.planup.domain.goal.convertor.GoalConvertor;
 import com.planup.planup.domain.goal.dto.CommunityResponseDto;
 import com.planup.planup.domain.goal.dto.GoalResponseDto;
@@ -8,6 +9,8 @@ import com.planup.planup.domain.goal.dto.UserGoalResponseDto;
 import com.planup.planup.domain.goal.repository.GoalRepository;
 import com.planup.planup.domain.goal.service.GoalService;
 import com.planup.planup.domain.goal.service.UserGoalService;
+import com.planup.planup.domain.user.entity.User;
+import com.planup.planup.domain.user.service.UserService;
 import com.planup.planup.validation.annotation.CurrentUser;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -23,6 +26,8 @@ import java.time.LocalDate;
 public class UserGoalController {
 
     private final UserGoalService userGoalService;
+    private final FriendService friendService;
+    private final UserService userService;
 
     @PostMapping("/{goalId}/join")
     @Operation(summary = "목표 참가 API", description = "커뮤니티 또는 친구가 생성한 목표에 참가합니다.")
@@ -57,6 +62,24 @@ public class UserGoalController {
             @Parameter(hidden = true) @CurrentUser Long userId) {
 
         UserGoalResponseDto.GoalTotalAchievementDto result = userGoalService.calculateGoalTotalAchievement(goalId, userId);
+
+        return ApiResponse.onSuccess(result);
+    }
+
+    @GetMapping("/friend/{friendId}/goal/{goalId}/total-achievement")
+    @Operation(summary = "친구 목표 전체 달성률 조회 API", description = "친구의 특정 목표 전체 달성률을 조회합니다.")
+    public ApiResponse<UserGoalResponseDto.GoalTotalAchievementDto> getFriendGoalTotalAchievement(
+            @Parameter(description = "친구 ID", example = "2")
+            @PathVariable Long friendId,
+            @Parameter(description = "목표 ID", example = "1")
+            @PathVariable Long goalId,
+            @Parameter(hidden = true) @CurrentUser Long userId) {
+        User user = userService.getUserbyUserId(userId);
+
+        friendService.isFriend(userId, friendId);
+
+        UserGoalResponseDto.GoalTotalAchievementDto result =
+                userGoalService.calculateGoalTotalAchievement(goalId, friendId);
 
         return ApiResponse.onSuccess(result);
     }

--- a/src/main/java/com/planup/planup/domain/goal/controller/UserGoalController.java
+++ b/src/main/java/com/planup/planup/domain/goal/controller/UserGoalController.java
@@ -1,7 +1,10 @@
 package com.planup.planup.domain.goal.controller;
 
 import com.planup.planup.apiPayload.ApiResponse;
+import com.planup.planup.domain.goal.convertor.GoalConvertor;
 import com.planup.planup.domain.goal.dto.CommunityResponseDto;
+import com.planup.planup.domain.goal.dto.GoalResponseDto;
+import com.planup.planup.domain.goal.dto.UserGoalResponseDto;
 import com.planup.planup.domain.goal.repository.GoalRepository;
 import com.planup.planup.domain.goal.service.GoalService;
 import com.planup.planup.domain.goal.service.UserGoalService;
@@ -9,10 +12,10 @@ import com.planup.planup.validation.annotation.CurrentUser;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
 
 @RestController
 @RequiredArgsConstructor
@@ -28,6 +31,32 @@ public class UserGoalController {
             @Parameter(hidden = true) @CurrentUser Long userId) {
 
         CommunityResponseDto.JoinGoalResponseDto result = userGoalService.joinGoal(userId, goalId);
+
+        return ApiResponse.onSuccess(result);
+    }
+
+    @GetMapping("/daily-achievement")
+    @Operation(summary = "일별 목표 달성률 조회 API", description = "특정 날짜의 사용자 전체 목표 달성률을 조회합니다.")
+    public ApiResponse<GoalResponseDto.DailyAchievementDto> getDailyAchievement(
+            @Parameter(description = "조회할 날짜 (yyyy-MM-dd 형식)", example = "2024-08-21")
+            @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate targetDate,
+            @Parameter(hidden = true) @CurrentUser Long userId) {
+
+        int achievementRate = userGoalService.calculateDailyAchievement(userId, targetDate);
+
+        GoalResponseDto.DailyAchievementDto result = GoalConvertor.toDailyAchievementDto(targetDate, achievementRate);
+
+        return ApiResponse.onSuccess(result);
+    }
+
+    @GetMapping("/{goalId}/total-achievement")
+    @Operation(summary = "목표 전체 달성률 조회 API", description = "특정 목표의 전체 달성률을 조회합니다.")
+    public ApiResponse<UserGoalResponseDto.GoalTotalAchievementDto> getGoalTotalAchievement(
+            @Parameter(description = "목표 ID", example = "1")
+            @PathVariable Long goalId,
+            @Parameter(hidden = true) @CurrentUser Long userId) {
+
+        UserGoalResponseDto.GoalTotalAchievementDto result = userGoalService.calculateGoalTotalAchievement(goalId, userId);
 
         return ApiResponse.onSuccess(result);
     }

--- a/src/main/java/com/planup/planup/domain/goal/convertor/GoalConvertor.java
+++ b/src/main/java/com/planup/planup/domain/goal/convertor/GoalConvertor.java
@@ -240,6 +240,16 @@ public class GoalConvertor {
                 .build();
     }
 
+    public static GoalResponseDto.DailyAchievementDto toDailyAchievementDto(
+            LocalDate date,
+            int achievementRate) {
+
+        return GoalResponseDto.DailyAchievementDto.builder()
+                .date(date)
+                .achievementRate(achievementRate)
+                .build();
+    }
+
     public static void updateMemoContent(GoalMemo existingMemo, String newMemo) {
         existingMemo.updateMemo(newMemo.trim());
     }

--- a/src/main/java/com/planup/planup/domain/goal/convertor/UserGoalConvertor.java
+++ b/src/main/java/com/planup/planup/domain/goal/convertor/UserGoalConvertor.java
@@ -1,6 +1,7 @@
 package com.planup.planup.domain.goal.convertor;
 
 import com.planup.planup.domain.goal.dto.CommunityResponseDto;
+import com.planup.planup.domain.goal.dto.UserGoalResponseDto;
 import com.planup.planup.domain.goal.entity.Goal;
 import com.planup.planup.domain.goal.entity.mapping.UserGoal;
 import com.planup.planup.domain.user.entity.User;
@@ -16,6 +17,16 @@ public class UserGoalConvertor {
                 .userId(user.getId())
                 .status(userGoal.getStatus())
                 .goalType(goal.getGoalType())
+                .build();
+    }
+
+    public static UserGoalResponseDto.GoalTotalAchievementDto toGoalTotalAchievementDto(
+            Long goalId,
+            int totalAchievementRate) {
+
+        return UserGoalResponseDto.GoalTotalAchievementDto.builder()
+                .goalId(goalId)
+                .totalAchievementRate(totalAchievementRate)
                 .build();
     }
 

--- a/src/main/java/com/planup/planup/domain/goal/dto/GoalResponseDto.java
+++ b/src/main/java/com/planup/planup/domain/goal/dto/GoalResponseDto.java
@@ -166,4 +166,16 @@ public class GoalResponseDto {
         private GoalPeriod period;
         private int frequency;
     }
+
+    @Builder
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class DailyAchievementDto {
+        @Schema(description = "조회 날짜", example = "2024-08-21")
+        private LocalDate date;
+
+        @Schema(description = "일별 총 달성률 (퍼센트)", example = "70")
+        private int achievementRate;
+    }
 }

--- a/src/main/java/com/planup/planup/domain/goal/dto/UserGoalResponseDto.java
+++ b/src/main/java/com/planup/planup/domain/goal/dto/UserGoalResponseDto.java
@@ -1,7 +1,19 @@
 package com.planup.planup.domain.goal.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 
 public class UserGoalResponseDto {
 
+    @Builder
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class GoalTotalAchievementDto {
+        @Schema(description = "목표 ID", example = "1")
+        private Long goalId;
+
+        @Schema(description = "전체 달성률 (퍼센트)", example = "85")
+        private int totalAchievementRate;
+    }
 }

--- a/src/main/java/com/planup/planup/domain/goal/repository/UserGoalRepository.java
+++ b/src/main/java/com/planup/planup/domain/goal/repository/UserGoalRepository.java
@@ -10,6 +10,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -62,4 +63,9 @@ public interface UserGoalRepository extends JpaRepository<UserGoal, Long> {
     int countByUserIdAndIsActiveTrue(Long id);
 
     List<UserGoal> findByUserIdAndIsActiveTrueOrderByCreatedAtAsc(Long id);
-}
+
+    @Query("SELECT ug FROM UserGoal ug " +
+            "WHERE ug.user = :user " +
+            "AND ug.isActive = true " +
+            "AND (ug.goal.endDate IS NULL OR ug.goal.endDate >= :targetDate)")
+    List<UserGoal> findActiveUserGoalsByUser(@Param("user") User user, @Param("targetDate") LocalDate targetDate);}

--- a/src/main/java/com/planup/planup/domain/goal/service/UserGoalService.java
+++ b/src/main/java/com/planup/planup/domain/goal/service/UserGoalService.java
@@ -1,5 +1,6 @@
 package com.planup.planup.domain.goal.service;
 
+import com.planup.planup.domain.goal.dto.UserGoalResponseDto;
 import com.planup.planup.domain.goal.entity.Enum.VerificationType;
 import com.planup.planup.domain.goal.dto.CommunityResponseDto;
 import com.planup.planup.domain.goal.entity.Goal;
@@ -8,6 +9,7 @@ import com.planup.planup.domain.user.entity.User;
 import org.springframework.cglib.core.Local;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -28,4 +30,8 @@ public interface UserGoalService {
 
     @Transactional(readOnly = true)
     boolean existUserGoal(Long goalId, Long userId);
-}
+
+    int calculateDailyAchievement(Long userId, LocalDate targetDate);
+    UserGoalResponseDto.GoalTotalAchievementDto calculateGoalTotalAchievement(Long goalId, Long userId);
+    List<UserGoal> getActiveUserGoalsByUser(Long userId, LocalDate targetDate);
+    }

--- a/src/main/java/com/planup/planup/domain/goal/service/UserGoalServiceImpl.java
+++ b/src/main/java/com/planup/planup/domain/goal/service/UserGoalServiceImpl.java
@@ -154,6 +154,7 @@ public class UserGoalServiceImpl implements UserGoalService{
     @Transactional(readOnly = true)
     public UserGoalResponseDto.GoalTotalAchievementDto calculateGoalTotalAchievement(Long goalId, Long userId) {
         UserGoal userGoal = userGoalRepository.findByGoalIdAndUserId(goalId, userId);
+
         if (userGoal == null) {
             throw new UserGoalException(ErrorStatus.NOT_FOUND_GOAL);
         }

--- a/src/main/java/com/planup/planup/domain/goal/service/UserGoalServiceImpl.java
+++ b/src/main/java/com/planup/planup/domain/goal/service/UserGoalServiceImpl.java
@@ -3,6 +3,9 @@ package com.planup.planup.domain.goal.service;
 import com.planup.planup.apiPayload.code.status.ErrorStatus;
 import com.planup.planup.apiPayload.exception.custom.UserGoalException;
 import com.planup.planup.domain.friend.service.FriendService;
+import com.planup.planup.domain.global.service.AchievementCalculationService;
+import com.planup.planup.domain.goal.dto.UserGoalResponseDto;
+import com.planup.planup.domain.goal.entity.Enum.GoalPeriod;
 import com.planup.planup.domain.goal.entity.Enum.VerificationType;
 import com.planup.planup.domain.goal.dto.CommunityResponseDto;
 import com.planup.planup.domain.goal.convertor.UserGoalConvertor;
@@ -14,13 +17,20 @@ import com.planup.planup.domain.goal.repository.GoalRepository;
 import com.planup.planup.domain.goal.repository.UserGoalRepository;
 import com.planup.planup.domain.user.entity.User;
 import com.planup.planup.domain.user.repository.UserRepository;
+import com.planup.planup.domain.verification.service.PhotoVerificationReadService;
+import com.planup.planup.domain.verification.service.TimerVerificationReadService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
@@ -31,6 +41,9 @@ public class UserGoalServiceImpl implements UserGoalService{
     private final GoalRepository goalRepository;
     private final UserRepository userRepository;
     private final FriendService friendService;
+    private final PhotoVerificationReadService photoVerificationReadService;
+    private final TimerVerificationReadService timerVerificationReadService;
+    private final AchievementCalculationService achievementCalculationService;
 
     @Transactional
     public CommunityResponseDto.JoinGoalResponseDto joinGoal(Long userId, Long goalId) {
@@ -84,6 +97,100 @@ public class UserGoalServiceImpl implements UserGoalService{
 
         friendService.isFriend(userId, creatorId);
 
+    }
+
+    //달성량 계산 파트
+    @Transactional(readOnly = true)
+    public int calculateDailyAchievement(Long userId, LocalDate targetDate) {
+        List<UserGoal> activeUserGoals = getActiveUserGoalsByUser(userId, targetDate);
+
+        if (activeUserGoals.isEmpty()) {
+            return 0;
+        }
+
+        List<Integer> achievementRates = new ArrayList<>();
+
+        for (UserGoal userGoal : activeUserGoals) {
+            int dailyRate = calculateSingleGoalAchievement(userGoal, targetDate);
+            achievementRates.add(dailyRate);
+        }
+
+        return (int) achievementRates.stream()
+                .mapToInt(Integer::intValue)
+                .average()
+                .orElse(0.0);
+    }
+
+    public int calculateSingleGoalAchievement(UserGoal userGoal, LocalDate targetDate) {
+        Goal goal = userGoal.getGoal();
+
+        LocalDateTime startOfDay = targetDate.atStartOfDay();
+        LocalDateTime endOfDay = targetDate.atTime(23, 59, 59);
+
+        Map<LocalDate, Integer> dailyCount;
+
+        if (goal.getVerificationType().equals(VerificationType.PHOTO)) {
+            dailyCount = photoVerificationReadService.calculateVerification(userGoal, startOfDay, endOfDay);
+        } else if (goal.getVerificationType().equals(VerificationType.TIMER)) {
+            dailyCount = timerVerificationReadService.calculateVerification(userGoal, startOfDay, endOfDay);
+        } else {
+            return 0;
+        }
+
+        int actualCount = dailyCount.getOrDefault(targetDate, 0);
+
+        return Math.min(100, (actualCount * 100) / goal.getOneDose());
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<UserGoal> getActiveUserGoalsByUser(Long userId, LocalDate targetDate) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new RuntimeException("존재하지 않는 유저입니다."));
+
+        return userGoalRepository.findActiveUserGoalsByUser(user, targetDate);
+    }
+
+    @Transactional(readOnly = true)
+    public UserGoalResponseDto.GoalTotalAchievementDto calculateGoalTotalAchievement(Long goalId, Long userId) {
+        UserGoal userGoal = userGoalRepository.findByGoalIdAndUserId(goalId, userId);
+        if (userGoal == null) {
+            throw new UserGoalException(ErrorStatus.NOT_FOUND_GOAL);
+        }
+
+        Goal goal = userGoal.getGoal();
+
+        LocalDate startDate = userGoal.getCreatedAt().toLocalDate();
+        LocalDate endDate = convertToLocalDate(goal.getEndDate());
+        LocalDate today = LocalDate.now();
+
+        long elapsedDays = ChronoUnit.DAYS.between(startDate, today.isAfter(endDate) ? endDate : today);
+        int expectedCount = calculateExpectedVerifications(goal.getFrequency(), goal.getPeriod(), elapsedDays);
+
+        int actualCount = userGoal.getVerificationCount();
+        int achievementRate = expectedCount > 0 ?
+                Math.min(100, (actualCount * 100) / expectedCount) : 0;
+
+        return UserGoalConvertor.toGoalTotalAchievementDto(goalId, achievementRate);
+    }
+
+    private int calculateExpectedVerifications(int frequency, GoalPeriod period, long days) {
+        if (days <= 0) return 0;
+
+        switch (period) {
+            case DAY:
+                return (int) (frequency * days);
+            case WEEK:
+                return (int) Math.ceil(frequency * (days / 7.0));
+            case MONTH:
+                return (int) Math.ceil(frequency * (days / 30.0));
+            default:
+                return 0;
+        }
+    }
+
+    private LocalDate convertToLocalDate(Date date) {
+        return date.toInstant().atZone(ZoneId.systemDefault()).toLocalDate();
     }
 
     //수용 형 파트


### PR DESCRIPTION
## 🚀 관련 이슈
- close #129 

## 📌 개요
목표 달성률 api 추가

## ✅ 기능 설명
- 일별 목표 달성률 api 추가 (5개의 활성화된 목표가 있다면 각각의 목표의 일일 달성률을 합산하여 반영)
- 목표 별 전체 달성률 api 추가
- ->현재까지 한 인증 횟수 / 전체 예상 횟수
-  ->(시작일과 종료일의 차이에서 빈도와 횟수에 따라 전체 예상 횟수 계산
- ex. 기간이 30일 1주일에 2회 하겠다. -> 전체 예상횟수 8회, verification count가 6일 경우 75%달성으로 반환
- 친구의 목표에 기록된 사진 및 시간 조회 가 가능하도록 별도의 컨트롤러 추가
## 📎 참고 자료
<!-- 관련 링크, 참고한 문서 등 -->