### PR TITLE
[Feat] : 응원/분발 api 추가 

### DIFF
--- a/src/main/java/com/planup/planup/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/planup/planup/apiPayload/code/status/ErrorStatus.java
@@ -83,6 +83,8 @@ public enum ErrorStatus implements BaseErrorCode {
     GOAL_CREATION_LIMIT_EXCEEDED(HttpStatus.FORBIDDEN, "GOAL4003", "목표 생성 제한을 초과했습니다"),
     INVALID_GOAL_END_DATE(HttpStatus.FORBIDDEN, "GOAL4004", "종료일이 생성일보다 빠릅니다."),
     DUPLICATE_GOAL_NAME(HttpStatus.FORBIDDEN, "GOAL4005", "중복되는 목표 입니다."),
+    ALREADY_REACTED(HttpStatus.FORBIDDEN,"GOAL4006", "이미 응원하였습니다."),
+    REACTION_ADD_FAILED(HttpStatus.FORBIDDEN,"GOAL4007", "응원 등록 중 오류가 발생했습니다."),
 
     // 랜덤 닉네임 관련 에러
     NICKNAME_DATA_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "NICKNAME5001", "닉네임 생성에 필요한 데이터가 없습니다.");

--- a/src/main/java/com/planup/planup/domain/goal/controller/GoalController.java
+++ b/src/main/java/com/planup/planup/domain/goal/controller/GoalController.java
@@ -297,5 +297,38 @@ public class GoalController {
 
         return ApiResponse.onSuccess(memos);
     }
+
+    @GetMapping("/{goalId}/reactions")
+    @Operation(summary = "목표 반응 조회 API", description = "특정 목표의 응원/분발 카운트와 현재 사용자의 반응 여부를 조회합니다.")
+    public ApiResponse<GoalResponseDto.GoalReactionDto> getGoalReactions(
+            @Parameter(description = "목표 ID", example = "1")
+            @PathVariable Long goalId,
+            @Parameter(hidden = true) @CurrentUser Long userId) {
+
+        GoalResponseDto.GoalReactionDto result = goalService.getGoalReactions(goalId, userId);
+        return ApiResponse.onSuccess(result);
+    }
+
+    @PostMapping("/{goalId}/reactions/cheer")
+    @Operation(summary = "응원하기 API", description = "특정 목표에 응원을 등록합니다. 하루에 한 번만 가능합니다.")
+    public ApiResponse<GoalResponseDto.ReactionResultDto> addCheer(
+            @Parameter(description = "목표 ID", example = "1")
+            @PathVariable Long goalId,
+            @Parameter(hidden = true) @CurrentUser Long userId) {
+
+        GoalResponseDto.ReactionResultDto result = goalService.addCheer(goalId, userId);
+        return ApiResponse.onSuccess(result);
+    }
+
+    @PostMapping("/{goalId}/reactions/encourage")
+    @Operation(summary = "분발하기 API", description = "특정 목표에 분발을 등록합니다. 하루에 한 번만 가능합니다.")
+    public ApiResponse<GoalResponseDto.ReactionResultDto> addEncourage(
+            @Parameter(description = "목표 ID", example = "1")
+            @PathVariable Long goalId,
+            @Parameter(hidden = true) @CurrentUser Long userId) {
+
+        GoalResponseDto.ReactionResultDto result = goalService.addEncourage(goalId, userId);
+        return ApiResponse.onSuccess(result);
+    }
 }
 

--- a/src/main/java/com/planup/planup/domain/goal/convertor/GoalConvertor.java
+++ b/src/main/java/com/planup/planup/domain/goal/convertor/GoalConvertor.java
@@ -252,6 +252,46 @@ public class GoalConvertor {
                 .build();
     }
 
+    public static GoalResponseDto.UserReactionStatus toUserReactionStatus(
+            boolean hasCheer,
+            boolean hasEncourage) {
+
+        return GoalResponseDto.UserReactionStatus.builder()
+                .hasCheer(hasCheer)
+                .hasEncourage(hasEncourage)
+                .build();
+    }
+
+    // 목표 반응 DTO 변환
+    public static GoalResponseDto.GoalReactionDto toGoalReactionDto(
+            Long goalId,
+            int cheerCount,
+            int encourageCount,
+            boolean hasCheer,
+            boolean hasEncourage) {
+
+        GoalResponseDto.UserReactionStatus userReactions = toUserReactionStatus(hasCheer, hasEncourage);
+
+        return GoalResponseDto.GoalReactionDto.builder()
+                .goalId(goalId)
+                .cheerCount(cheerCount)
+                .encourageCount(encourageCount)
+                .userReactions(userReactions)
+                .build();
+    }
+
+    // 반응 성공 결과 DTO 변환
+    public static GoalResponseDto.ReactionResultDto toSuccessReactionResult(
+            String message,
+            GoalResponseDto.GoalReactionDto reactionData) {
+
+        return GoalResponseDto.ReactionResultDto.builder()
+                .result("SUCCESS")
+                .message(message)
+                .reactionData(reactionData)
+                .build();
+    }
+
     public static void updateMemoContent(GoalMemo existingMemo, String newMemo) {
         existingMemo.updateMemo(newMemo.trim());
     }

--- a/src/main/java/com/planup/planup/domain/goal/convertor/GoalConvertor.java
+++ b/src/main/java/com/planup/planup/domain/goal/convertor/GoalConvertor.java
@@ -105,6 +105,7 @@ public class GoalConvertor {
                 .goalId(goal.getId())
                 .goalName(goal.getGoalName())
                 .goalAmount(goal.getGoalAmount())
+                .goalPeriod(goal.getPeriod())
                 .goalType(goal.getGoalType())
                 .verificationType(goal.getVerificationType())
                 .goalTime(friendGoal.getGoalTime())

--- a/src/main/java/com/planup/planup/domain/goal/dto/GoalResponseDto.java
+++ b/src/main/java/com/planup/planup/domain/goal/dto/GoalResponseDto.java
@@ -72,6 +72,7 @@ public class GoalResponseDto {
         private String goalName;
         private GoalType goalType;
         private String goalAmount;
+        private GoalPeriod goalPeriod;
         private VerificationType verificationType;
         private Integer goalTime;
         private int frequency;

--- a/src/main/java/com/planup/planup/domain/goal/dto/GoalResponseDto.java
+++ b/src/main/java/com/planup/planup/domain/goal/dto/GoalResponseDto.java
@@ -180,4 +180,51 @@ public class GoalResponseDto {
         @Schema(description = "일별 총 달성률 (퍼센트)", example = "70")
         private int achievementRate;
     }
+
+    @Builder
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class GoalReactionDto {
+        @Schema(description = "목표 ID", example = "123")
+        private Long goalId;
+
+        @Schema(description = "응원해요 카운트", example = "15")
+        private int cheerCount;
+
+        @Schema(description = "분발해요 카운트", example = "8")
+        private int encourageCount;
+
+        @Schema(description = "사용자 반응 여부")
+        private UserReactionStatus userReactions;
+    }
+
+    //사용자 반응 상태 DTO
+    @Builder
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class UserReactionStatus {
+        @Schema(description = "응원해요 클릭 여부", example = "true")
+        private boolean hasCheer;
+
+        @Schema(description = "분발해요 클릭 여부", example = "false")
+        private boolean hasEncourage;
+    }
+
+    //반응 추가 결과 DTO
+    @Builder
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ReactionResultDto {
+        @Schema(description = "처리 결과", example = "SUCCESS", allowableValues = {"SUCCESS", "ALREADY_REACTED", "ERROR"})
+        private String result;
+
+        @Schema(description = "결과 메시지", example = "응원이 등록되었습니다.")
+        private String message;
+
+        @Schema(description = "업데이트된 반응 정보")
+        private GoalReactionDto reactionData;
+    }
 }

--- a/src/main/java/com/planup/planup/domain/goal/service/GoalService.java
+++ b/src/main/java/com/planup/planup/domain/goal/service/GoalService.java
@@ -38,6 +38,9 @@ public interface GoalService {
     GoalResponseDto.DailyVerifiedGoalsResponse getDailyVerifiedGoals(Long userId, LocalDate date);
     GoalResponseDto.GoalMemoReadDto getMemo(Long userId, Long goalId, LocalDate date);
     List<GoalResponseDto.GoalMemoReadDto> getMemosByPeriod(Long userId, Long goalId, LocalDate startDate, LocalDate endDate);
+    GoalResponseDto.GoalReactionDto getGoalReactions(Long goalId, Long userId);
+    GoalResponseDto.ReactionResultDto addCheer(Long goalId, Long userId);
+    GoalResponseDto.ReactionResultDto addEncourage(Long goalId, Long userId);
 
     Goal getGoalById(Long challengeId);
 

--- a/src/main/java/com/planup/planup/domain/user/service/UserStatService.java
+++ b/src/main/java/com/planup/planup/domain/user/service/UserStatService.java
@@ -1,4 +1,7 @@
 package com.planup.planup.domain.user.service;
 
+import com.planup.planup.domain.bedge.entity.UserStat;
+
 public interface UserStatService {
+    UserStat getUserStatByUserId(Long userId);
 }

--- a/src/main/java/com/planup/planup/domain/user/service/UserStatServiceImpl.java
+++ b/src/main/java/com/planup/planup/domain/user/service/UserStatServiceImpl.java
@@ -1,11 +1,27 @@
 package com.planup.planup.domain.user.service;
 
+import com.planup.planup.apiPayload.code.status.ErrorStatus;
+import com.planup.planup.apiPayload.exception.custom.UserException;
+import com.planup.planup.domain.bedge.entity.UserStat;
+import com.planup.planup.domain.user.entity.User;
+import com.planup.planup.domain.user.repository.UserRepository;
+import com.planup.planup.domain.user.repository.UserStatRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class UserStatServiceImpl implements UserStatService {
+    private final UserStatRepository userStatRepository;
+    private final UserService userService;
+    @Override
+    public UserStat getUserStatByUserId(Long userId) {
+        User user = userService.getUserbyUserId(userId);
 
+        UserStat userStat = userStatRepository.findByUser(user);
+
+        return userStat;
+    }
 
 }


### PR DESCRIPTION
## 🚀 관련 이슈

## 📌 개요
목표 상세 조회시 응원, 분발 api 추가

## ✅ 기능 설명
매일 초기화 되며, 저장될 필요 없는 것이기에 레디스를 통해 구현
유저가 응원 혹은 분발을 클릭시 UserStat에 적용되어 뱃지발급을 위한 통계 업데이트 추가