### PR TITLE
[FIX] 프로필 이미지 업로드 API에서 JWT 인증 삭제

### DIFF
--- a/src/main/java/com/planup/planup/config/SecurityConfig.java
+++ b/src/main/java/com/planup/planup/config/SecurityConfig.java
@@ -28,6 +28,7 @@ public class SecurityConfig {
                 )
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/users/signup", "/users/login").permitAll()
+                        .requestMatchers("/profile/image").permitAll()
                         // Swagger 관련 경로
                         .requestMatchers(
                                 "/v3/api-docs/**",

--- a/src/main/java/com/planup/planup/domain/user/controller/UserController.java
+++ b/src/main/java/com/planup/planup/domain/user/controller/UserController.java
@@ -134,9 +134,10 @@ public class UserController {
     public ApiResponse<ImageUploadResponseDTO> uploadProfileImage(
             @Parameter(description = "업로드할 이미지 파일", required = true)
             @RequestPart("file") MultipartFile file,
-            @Parameter(hidden = true) @CurrentUser User currentUser) {
+            @Parameter(description = "회원가입할 이메일 주소", required = true)
+            @RequestParam String email) {
 
-        ImageUploadResponseDTO response = userService.uploadProfileImage(file, currentUser);
+        ImageUploadResponseDTO response = userService.uploadProfileImage(file, email);
         return ApiResponse.onSuccess(response);
     }
 

--- a/src/main/java/com/planup/planup/domain/user/service/UserService.java
+++ b/src/main/java/com/planup/planup/domain/user/service/UserService.java
@@ -45,7 +45,7 @@ public interface UserService {
 
     KakaoAccountResponseDTO getKakaoAccountStatus(Long userId);
 
-    ImageUploadResponseDTO uploadProfileImage(MultipartFile file, User currentUser);
+    ImageUploadResponseDTO uploadProfileImage(MultipartFile file, String email);
 
     InviteCodeResponseDTO getMyInviteCode(Long userId);
 

--- a/src/main/java/com/planup/planup/validation/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/planup/planup/validation/jwt/JwtAuthenticationFilter.java
@@ -82,6 +82,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         return path.equals("/login") ||
                 path.equals("/users/join") ||
                 path.equals("/users/check-duplicate") ||
+                path.equals("/profile/image") ||
                 path.startsWith("/swagger-ui") ||
                 path.startsWith("/v3/api-docs") ||
                 path.equals("/swagger-ui.html") ||


### PR DESCRIPTION
## 📌 개요
프로필 이미지 업로드 API에서 JWT 인증 삭제

## ✅ 기능 설명
- 프로필 이미지 변경 및 등록 API를 JWT 인증 없이도 호출 가능하도록 수정
- 업로드된 이미지와 유저를 연결시키기 위해 이미지와 회원가입할 이메일을 Redis에 임시 저장 (TTL 1시간)
- 회원가입 시 Redis에서 해당되는 이미지 찾아서 연결


