### PR TITLE
[REF] 로그인 API refreshToken 누락 및 이메일 인증 상태 확인 API 개선

### DIFF
--- a/src/main/java/com/planup/planup/domain/user/converter/UserAuthConverter.java
+++ b/src/main/java/com/planup/planup/domain/user/converter/UserAuthConverter.java
@@ -70,9 +70,11 @@ public class UserAuthConverter {
     /**
      * User 엔티티를 로그인 응답 DTO로 변환
      */
-    public UserResponseDTO.Login toLoginResponseDTO(User user, String accessToken) {
+    public UserResponseDTO.Login toLoginResponseDTO(User user, String accessToken, String refreshToken, Long expiresIn) {
         return UserResponseDTO.Login.builder()
                 .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .expiresIn(expiresIn)
                 .nickname(user.getNickname())
                 .profileImgUrl(user.getProfileImg())
                 .build();

--- a/src/main/java/com/planup/planup/domain/user/converter/UserAuthConverter.java
+++ b/src/main/java/com/planup/planup/domain/user/converter/UserAuthConverter.java
@@ -166,19 +166,19 @@ public class UserAuthConverter {
      * 이메일 인증 상태 응답 DTO 생성
      */
     public AuthResponseDTO.EmailVerificationStatus toEmailVerificationStatusResponseDTO(String email, boolean verified) {
-        if (email != null) {
-            return AuthResponseDTO.EmailVerificationStatus.builder()
-                    .verified(verified)
-                    .email(email)
-                    .tokenStatus(TokenStatus.VALID)
-                    .build();
-        } else {
-            return AuthResponseDTO.EmailVerificationStatus.builder()
-                    .verified(verified)
-                    .email(null)
-                    .tokenStatus(TokenStatus.EXPIRED_OR_INVALID)
-                    .build();
-        }
+        TokenStatus tokenStatus = email != null ? TokenStatus.VALID : TokenStatus.EXPIRED_OR_INVALID;
+        return toEmailVerificationStatusResponseDTO(email, verified, tokenStatus);
+    }
+
+    /**
+     * 이메일 인증 상태 응답 DTO 생성 (tokenStatus 지정)
+     */
+    public AuthResponseDTO.EmailVerificationStatus toEmailVerificationStatusResponseDTO(String email, boolean verified, TokenStatus tokenStatus) {
+        return AuthResponseDTO.EmailVerificationStatus.builder()
+                .verified(verified)
+                .email(email)
+                .tokenStatus(tokenStatus)
+                .build();
     }
 
     // ======= 약관동의 =======

--- a/src/main/java/com/planup/planup/domain/user/service/command/UserAuthCommandServiceImpl.java
+++ b/src/main/java/com/planup/planup/domain/user/service/command/UserAuthCommandServiceImpl.java
@@ -137,9 +137,13 @@ public class UserAuthCommandServiceImpl implements UserAuthCommandService {
             throw new UserException(ErrorStatus.INVALID_CREDENTIALS);
         }
 
-        String accessToken = jwtUtil.generateToken(user.getEmail(), user.getRole().toString(), user.getId());
+        // 토큰 발급 (액세스 토큰 + 리프레시 토큰)
+        TokenResponseDTO tokenResponse = tokenService.generateTokens(user);
 
-        return userAuthConverter.toLoginResponseDTO(user, accessToken);
+        return userAuthConverter.toLoginResponseDTO(user, 
+                tokenResponse.getAccessToken(), 
+                tokenResponse.getRefreshToken(), 
+                tokenResponse.getExpiresIn());
     }
 
     @Override

--- a/src/main/java/com/planup/planup/domain/user/service/command/UserAuthCommandServiceImpl.java
+++ b/src/main/java/com/planup/planup/domain/user/service/command/UserAuthCommandServiceImpl.java
@@ -478,8 +478,13 @@ public class UserAuthCommandServiceImpl implements UserAuthCommandService {
                     TimeUnit.MINUTES
             );
 
-            // 사용한 인증 토큰은 삭제 (재사용 방지)
-            redisTemplate.delete("email-verification:" + verificationToken);
+            // 토큰을 삭제하지 않고 인증 완료 상태로 변경 (60분 유효, 프론트엔드 상태 확인용)
+            redisTemplate.opsForValue().set(
+                    "email-verification:" + verificationToken,
+                    "VERIFIED:" + email,
+                    60,
+                    TimeUnit.MINUTES
+            );
 
             return email;
 


### PR DESCRIPTION
## 🚀 관련 이슈
<!-- 이슈 번호를 작성하여 종료시켜주세요 -->
- close #188

## 🔑 주요 변경사항
<!-- 내가 작업한 내용에 대해 작성해주세요! -->
- 로그인 API에서 refreshToken, expiresIn 응답에 포함
- 이메일 인증 완료 후 토큰 삭제 대신 VERIFIED 플래그로 변경
- 인증 완료 후 60분간 verified: true 응답 가능하도록 개선

## ✔️ 체크 리스트
- [x] Merge 하려는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x] 작업한 API에 대해 적절한 **예외처리**가 이루어졌는가?
- [x] 작업한 API에 대해 적절한 **로그 메시지**가 작성되었는가? (`Controller`나 `Service`에서 `log.error` 활용)
- [x] Merge 하려는 PR 및 Commit들을 **로컬**에서 실행했을 때 에러가 발생하지 않았는가?

## ↗️ 개선 사항
<!-- 작업한 내용에 대해 좀 더 개선해야할 부분을 작성해주세요! -->

## 📔 참고 자료
- 선택 사항
