### PR TITLE
[FIX] 스웨거 예시 응답값과 실제 응답값 포맷 불일치 문제 해결 

### DIFF
--- a/src/main/java/com/planup/planup/domain/user/controller/UserAuthController.java
+++ b/src/main/java/com/planup/planup/domain/user/controller/UserAuthController.java
@@ -89,7 +89,7 @@ public class UserAuthController {
 
     @Operation(summary = "비밀번호 변경", description = "현재 유저의 비밀번호를 변경한다.")
     @PostMapping("/password/change")
-    public ApiResponse<Boolean> changePasswordWithToken(@RequestBody UserRequestDTO.PasswordChange request, @CurrentUser Long userId) {
+    public ApiResponse<Boolean> changePasswordWithToken(@RequestBody UserRequestDTO.PasswordChangeWithToken request, @CurrentUser Long userId) {
         userAuthCommandService.changePassword(userId, request.getNewPassword());
         return ApiResponse.onSuccess(true);
     }

--- a/src/main/java/com/planup/planup/domain/user/dto/AuthRequestDTO.java
+++ b/src/main/java/com/planup/planup/domain/user/dto/AuthRequestDTO.java
@@ -12,6 +12,7 @@ public class AuthRequestDTO {
 
     @Getter
     @Setter
+    @Schema(name = "AuthEmailVerificationRequest")
     public static class EmailVerification {
         @Schema(description = "이메일", example = "user@planup.com")
         @Email @NotBlank(message = "이메일은 필수입니다")
@@ -20,6 +21,7 @@ public class AuthRequestDTO {
 
     @Getter
     @Setter
+    @Schema(name = "AuthInviteCodeRequest")
     public static class InviteCode {
         @Schema(description = "초대코드", example = "123456")
         @NotBlank(message = "초대코드를 입력해주세요")
@@ -28,6 +30,7 @@ public class AuthRequestDTO {
 
     @Getter
     @Setter
+    @Schema(name = "AuthTermsAgreementRequest")
     public static class TermsAgreement {
         @Schema(description = "약관 ID", example = "1")
         @NotNull

--- a/src/main/java/com/planup/planup/domain/user/dto/AuthResponseDTO.java
+++ b/src/main/java/com/planup/planup/domain/user/dto/AuthResponseDTO.java
@@ -13,6 +13,7 @@ public class AuthResponseDTO {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
+    @Schema(name = "AuthEmailDuplicateResponse")
     public static class EmailDuplicate {
         @Schema(description = "이메일 사용 가능 여부", example = "true")
         private boolean available;
@@ -25,6 +26,7 @@ public class AuthResponseDTO {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
+    @Schema(name = "AuthEmailSendResponse")
     public static class EmailSend {
         @Schema(description = "이메일", example = "user@planup.com")
         @Email
@@ -41,6 +43,7 @@ public class AuthResponseDTO {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
+    @Schema(name = "AuthEmailVerificationStatusResponse")
     public static class EmailVerificationStatus {
         @Schema(description = "인증 완료 여부", example = "true")
         private Boolean verified;
@@ -56,6 +59,7 @@ public class AuthResponseDTO {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
+    @Schema(name = "AuthEmailVerifyLinkResponse")
     public static class EmailVerifyLink {
         private boolean verified;
         private String email;
@@ -68,6 +72,7 @@ public class AuthResponseDTO {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
+    @Schema(name = "AuthInviteCodeResponse")
     public static class InviteCode {
         @Schema(description = "내 초대코드", example = "123456")
         private String inviteCode;
@@ -83,6 +88,7 @@ public class AuthResponseDTO {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
+    @Schema(name = "AuthInviteCodeProcessResponse")
     public static class InviteCodeProcess {
         @Schema(description = "초대코드로 친구가 된 사용자 닉네임", example = "라미")
         private String friendNickname;
@@ -98,6 +104,7 @@ public class AuthResponseDTO {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
+    @Schema(name = "AuthTermsDetailResponse")
     public static class TermsDetail {
         @Schema(description = "약관 ID", example = "1")
         private Long id;
@@ -110,6 +117,7 @@ public class AuthResponseDTO {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
+    @Schema(name = "AuthTermsListResponse")
     public static class TermsList {
         @Schema(description = "약관 ID", example = "1")
         private Long id;
@@ -128,6 +136,7 @@ public class AuthResponseDTO {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
+    @Schema(name = "AuthValidateInviteCodeResponse")
     public static class ValidateInviteCode {
         @Schema(description = "초대코드 유효성", example = "true")
         private boolean valid;

--- a/src/main/java/com/planup/planup/domain/user/dto/FileResponseDTO.java
+++ b/src/main/java/com/planup/planup/domain/user/dto/FileResponseDTO.java
@@ -1,5 +1,6 @@
 package com.planup.planup.domain.user.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -11,6 +12,7 @@ public class FileResponseDTO {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
+    @Schema(name = "FileImageUploadResponse")
     public static class ImageUpload {
         private String imageUrl;
     }

--- a/src/main/java/com/planup/planup/domain/user/dto/OAuthRequestDTO.java
+++ b/src/main/java/com/planup/planup/domain/user/dto/OAuthRequestDTO.java
@@ -13,6 +13,7 @@ public class OAuthRequestDTO {
 
     @Getter
     @Setter
+    @Schema(name = "OAuthKakaoAuthRequest")
     public static class KakaoAuth {
         @NotBlank(message = "카카오 인가코드는 필수입니다")
         private String code;
@@ -20,6 +21,7 @@ public class OAuthRequestDTO {
 
     @Getter
     @Setter
+    @Schema(name = "OAuthKakaoLinkRequest")
     public static class KaKaoLink {
         @NotBlank(message = "카카오 인가코드는 필수입니다")
         private String code;
@@ -27,7 +29,7 @@ public class OAuthRequestDTO {
 
     @Getter
     @Setter
-    @Schema(description = "카카오 회원가입 완료 요청")
+    @Schema(name = "OAuthKakaoSignupRequest", description = "카카오 회원가입 완료 요청")
     public static class KaKaoSignup {
 
         @NotBlank(message = "임시 사용자 ID는 필수입니다")

--- a/src/main/java/com/planup/planup/domain/user/dto/OAuthResponseDTO.java
+++ b/src/main/java/com/planup/planup/domain/user/dto/OAuthResponseDTO.java
@@ -1,6 +1,7 @@
 package com.planup.planup.domain.user.dto;
 
 import lombok.*;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 public class OAuthResponseDTO {
 
@@ -8,6 +9,7 @@ public class OAuthResponseDTO {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
+    @Schema(name = "OAuthKakaoAccountResponse")
     public static class KakaoAccount {
         private boolean isLinked; // 카카오톡 계정 연동 여부
         private String kakaoEmail; // 연동된 카카오톡 이메일 (연동되지 않은 경우 null)
@@ -17,6 +19,7 @@ public class OAuthResponseDTO {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
+    @Schema(name = "OAuthKakaoAuthResponse")
     public static class KakaoAuth {
         private boolean isNewUser;
         private String tempUserId;   // 신규 사용자인 경우
@@ -30,6 +33,7 @@ public class OAuthResponseDTO {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
+    @Schema(name = "OAuthKakaoLinkResponse")
     public static class KaKaoLink {
         private boolean success;
         private String message;

--- a/src/main/java/com/planup/planup/domain/user/dto/UserRequestDTO.java
+++ b/src/main/java/com/planup/planup/domain/user/dto/UserRequestDTO.java
@@ -12,6 +12,7 @@ public class UserRequestDTO {
 
     @Getter
     @Setter
+    @Schema(name = "UserLoginRequest")
     public static class Login {
         @NotBlank @Email @Schema(description = "이메일", example = "june5355@naver.com")
         private String email;
@@ -22,6 +23,7 @@ public class UserRequestDTO {
 
     @Getter
     @Setter
+    @Schema(name = "UserPasswordChangeEmailRequest")
     public static class PasswordChangeEmail {
         @NotBlank(message = "이메일은 필수입니다.")
         @Email(message = "유효한 이메일 형식이 아닙니다.")
@@ -32,6 +34,7 @@ public class UserRequestDTO {
 
     @Getter
     @Setter
+    @Schema(name = "UserSignupRequest")
     public static class Signup {
         @Schema(description = "이메일", example = "user@planup.com")
         @NotBlank
@@ -68,7 +71,11 @@ public class UserRequestDTO {
 
     @Getter
     @Setter
-    public static class PasswordChange {
+    @Schema(name = "UserPasswordChangeWithTokenRequest")
+    public static class PasswordChangeWithToken {
+        @NotBlank(message = "인증 토큰은 필수입니다.")
+        private String token;
+
         @NotBlank(message = "새 비밀번호는 필수입니다.")
         @Size(min = 8, message = "비밀번호는 최소 8자 이상이어야 합니다.")
         private String newPassword;
@@ -76,6 +83,7 @@ public class UserRequestDTO {
 
     @Getter
     @Setter
+    @Schema(name = "UserWithdrawalRequest")
     public static class Withdrawal {
         @Schema(description = "탈퇴 이유", example = "서비스 불만족")
         @NotBlank(message = "탈퇴 이유를 입력해주세요.")
@@ -85,6 +93,7 @@ public class UserRequestDTO {
 
     @Getter
     @Setter
+    @Schema(name = "UserUpdateNicknameRequest")
     public static class UpdateNickname {
         @NotBlank(message = "닉네임은 비어 있을 수 없습니다.")
         @Schema(example = "닉네임")

--- a/src/main/java/com/planup/planup/domain/user/dto/UserResponseDTO.java
+++ b/src/main/java/com/planup/planup/domain/user/dto/UserResponseDTO.java
@@ -13,6 +13,7 @@ public class UserResponseDTO {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
+    @Schema(name = "UserLoginResponse")
     public static class Login {
         @Schema(description = "JWT 액세스 토큰", example = "eyJhbGciOiJIUz...")
         private String accessToken;
@@ -34,6 +35,7 @@ public class UserResponseDTO {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
+    @Schema(name = "UserSignupResponse")
     public static class Signup {
         @Schema(description = "회원 고유 ID", example = "1")
         private Long id;
@@ -57,6 +59,7 @@ public class UserResponseDTO {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
+    @Schema(name = "UserRandomNicknameResponse")
     public static class RandomNickname {
         @Schema(description = "랜덤 닉네임", example = "행복한고양이")
         private String nickname;
@@ -66,6 +69,7 @@ public class UserResponseDTO {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
+    @Schema(name = "UserWithdrawalResponse")
     public static class Withdrawal {
         @Schema(description = "탈퇴 성공 여부", example = "true")
         private boolean success;
@@ -81,6 +85,7 @@ public class UserResponseDTO {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
+    @Schema(name = "UserResponseUserInfo")
     public static class UserInfo {
         private Long id;
         private String email;


### PR DESCRIPTION
## 🚀 관련 이슈
<!-- 이슈 번호를 작성하여 종료시켜주세요 -->
- close #200 

## 🔑 주요 변경사항
<!-- 내가 작업한 내용에 대해 작성해주세요! -->
- 스웨거 예시 응답값과 실제 응답값 포맷 불일치 문제 
  - 원인:  UserRequestDTO와 UserResponseDTO 내부에 동일한 이름의 클래스(Signup)가 존재하여 Swagger(SpringDoc)가 스키마를 생성할 때 충돌이 발생
  - 해결:  @Schema(name = "...") 어노테이션을 사용하여 각 DTO 클래스에 고유한 스키마 이름을 부여

## ✔️ 체크 리스트
- [x] Merge 하려는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x] 작업한 API에 대해 적절한 **예외처리**가 이루어졌는가?
- [x] 작업한 API에 대해 적절한 **로그 메시지**가 작성되었는가? (`Controller`나 `Service`에서 `log.error` 활용)
- [x] Merge 하려는 PR 및 Commit들을 **로컬**에서 실행했을 때 에러가 발생하지 않았는가?

## ↗️ 개선 사항
<!-- 작업한 내용에 대해 좀 더 개선해야할 부분을 작성해주세요! -->

## 📔 참고 자료
- 선택 사항
