### PR TITLE
[FEATURE] 카카오 로그인 구현 방식 변경 

### DIFF
--- a/src/main/java/com/planup/planup/domain/user/controller/UserAuthController.java
+++ b/src/main/java/com/planup/planup/domain/user/controller/UserAuthController.java
@@ -27,7 +27,7 @@ import com.planup.planup.domain.user.dto.OAuthResponseDTO;
 @RequiredArgsConstructor
 @Slf4j
 @RequestMapping("/users")
-public class UserAuthController {
+public class UserAuthController implements UserAuthControllerDocs {
 
     private final UserAuthCommandService userAuthCommandService;
     private final TokenService tokenService;

--- a/src/main/java/com/planup/planup/domain/user/controller/UserAuthControllerDocs.java
+++ b/src/main/java/com/planup/planup/domain/user/controller/UserAuthControllerDocs.java
@@ -1,0 +1,149 @@
+package com.planup.planup.domain.user.controller;
+
+import com.planup.planup.apiPayload.ApiResponse;
+import com.planup.planup.domain.user.dto.*;
+import com.planup.planup.validation.jwt.dto.TokenRefreshRequestDTO;
+import com.planup.planup.validation.jwt.dto.TokenRefreshResponseDTO;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Tag(name = "User Auth Controller", description = "유저 인증/인가, 소셜 로그인 및 계정 관리 API")
+public interface UserAuthControllerDocs {
+
+    // ======================== 기본 인증 (가입/로그인/토큰) ========================
+
+    @Operation(summary = "회원가입", description = "이메일/비밀번호로 새 계정을 생성합니다.")
+    ApiResponse<UserResponseDTO.Signup> signup(@RequestBody UserRequestDTO.Signup request);
+
+    @Operation(summary = "로그인", description = "이메일/비밀번호로 로그인하여 JWT 토큰을 발급받습니다.")
+    ApiResponse<UserResponseDTO.Login> login(@RequestBody UserRequestDTO.Login request);
+
+    @Operation(summary = "로그아웃", description = "현재 사용자를 로그아웃합니다.")
+    ApiResponse<String> logout(@Parameter(hidden = true) Long userId, HttpServletRequest httpRequest);
+
+    @Operation(summary = "토큰 갱신", description = "리프레쉬 토큰을 사용하여 새로운 액세스 토큰을 발급받습니다.")
+    ApiResponse<TokenRefreshResponseDTO> refreshToken(@RequestBody TokenRefreshRequestDTO request);
+
+    @Operation(summary = "토큰 유효성 확인", description = "현재 액세스 토큰의 유효성을 확인합니다.")
+    ApiResponse<String> validateToken(@Parameter(hidden = true) Long userId);
+
+    // ======================== 계정 검증 및 복구 (이메일/비밀번호) ========================
+
+    @Operation(summary = "이메일 중복 확인", description = "이메일이 이미 사용 중인지 확인합니다.")
+    ApiResponse<AuthResponseDTO.EmailDuplicate> checkEmailDuplicate(@RequestParam String email);
+
+    @Operation(summary = "비밀번호 변경", description = "현재 유저의 비밀번호를 변경합니다.")
+    ApiResponse<Boolean> changePasswordWithToken(@RequestBody UserRequestDTO.PasswordChangeWithToken request, @Parameter(hidden = true) Long userId);
+
+    @Operation(summary = "이메일 인증 발송", description = "이메일 중복 확인 후 인증메일을 발송하고 토큰을 반환합니다.")
+    ApiResponse<AuthResponseDTO.EmailSend> sendEmailVerification(@RequestBody AuthRequestDTO.EmailVerification request);
+
+    @Operation(summary = "이메일 인증 재발송", description = "기존 이메일로 인증 메일을 재발송합니다.")
+    ApiResponse<AuthResponseDTO.EmailSend> resendVerificationEmail(@RequestBody AuthRequestDTO.EmailVerification request);
+
+    @Operation(summary = "이메일 인증 여부 확인", description = "토큰으로 이메일을 확인하고 인증 상태를 반환합니다.")
+    ApiResponse<AuthResponseDTO.EmailVerificationStatus> getEmailVerificationStatus(@RequestParam("token") String token);
+
+    @Operation(summary = "이메일 링크 클릭 처리", description = "이메일 링크 클릭 시 인증 처리 후 웹페이지(HTML)를 반환합니다.")
+    ResponseEntity<String> handleEmailLink(@RequestParam String token);
+
+    @Operation(summary = "비밀번호 변경 확인 이메일 발송", description = "비밀번호 변경을 위한 확인 메일을 발송하고 토큰을 반환합니다.")
+    ApiResponse<AuthResponseDTO.EmailSend> sendPasswordChangeEmail(@RequestBody UserRequestDTO.PasswordChangeEmail request);
+
+    @Operation(summary = "비밀번호 변경 확인 이메일 재발송", description = "비밀번호 변경을 위한 확인 메일을 재발송합니다.")
+    ApiResponse<AuthResponseDTO.EmailSend> resendPasswordChangeEmail(@RequestBody UserRequestDTO.PasswordChangeEmail request);
+
+    @Operation(summary = "비밀번호 변경 요청 이메일 링크 클릭 처리", description = "비밀번호 변경 링크 클릭 시 확인 처리 후 웹페이지(HTML)를 반환합니다.")
+    ResponseEntity<String> handlePasswordChangeLink(@RequestParam String token);
+
+    // ======================== 소셜 인증 및 연동 (핵심 변경 사항) ========================
+
+    @Operation(summary = "카카오 소셜 인증", description = "카카오 인가코드로 로그인 또는 회원가입 여부를 판단합니다.")
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "요청 성공",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ApiResponse.class),
+                            examples = {
+                                    @ExampleObject(name = "1. 로그인 성공 (기존 유저)",
+                                            description = "이미 가입된 유저입니다. 액세스 토큰과 유저 정보를 반환합니다.",
+                                            value = """
+                                                {
+                                                  "isSuccess": true,
+                                                  "code": "COMMON200",
+                                                  "message": "성공입니다.",
+                                                  "result": {
+                                                    "tempUserId": null,
+                                                    "accessToken": "eyJhbGciOiJIUzUxMiJ9.eyJyb...",
+                                                    "refreshToken": "eyJhbGciOiJIUzUxMiJ9.eyJ1c...",
+                                                    "expiresIn": 3600,
+                                                    "userInfo": {
+                                                      "id": 46,
+                                                      "email": "test@planup.com",
+                                                      "nickname": "테스트유저",
+                                                      "profileImg": "string",
+                                                      "serviceNotificationAllow": true,
+                                                      "marketingNotificationAllow": true
+                                                    },
+                                                    "newUser": false
+                                                  }
+                                                }
+                                                """
+                                    ),
+                                    @ExampleObject(name = "2. 회원가입 필요 (신규 유저)",
+                                            description = "가입되지 않은 유저입니다. tempUserId를 반환하며, 이를 이용해 회원가입 완료 API를 호출해야 합니다.",
+                                            value = """
+                                                {
+                                                  "isSuccess": true,
+                                                  "code": "COMMON200",
+                                                  "message": "성공입니다.",
+                                                  "result": {
+                                                    "tempUserId": "4423fc15-ad4d-45b8-a153-81c50f3fe223",
+                                                    "accessToken": null,
+                                                    "refreshToken": null,
+                                                    "expiresIn": null,
+                                                    "userInfo": null,
+                                                    "newUser": true
+                                                  }
+                                                }
+                                                """
+                                    )
+                            }
+                    )
+            )
+    })
+    ApiResponse<OAuthResponseDTO.KakaoAuth> kakaoAuth(@RequestBody OAuthRequestDTO.KakaoAuth request);
+
+    @Operation(summary = "카카오 회원가입 완료", description = "카카오 온보딩 완료 후 모든 정보를 받아서 회원가입을 완료합니다.")
+    ApiResponse<UserResponseDTO.Signup> kakaoSignupComplete(@RequestBody OAuthRequestDTO.KaKaoSignup request);
+
+    @Operation(summary = "이메일 인증 대안 - 카카오 로그인", description = "이메일 인증 실패 시 카카오 소셜 로그인으로 전환합니다.")
+    ApiResponse<OAuthResponseDTO.KakaoAuth> emailAuthAlternative(@RequestBody OAuthRequestDTO.KakaoAuth request);
+
+    @Operation(summary = "카카오 계정 연동 여부 조회", description = "현재 로그인한 사용자의 카카오 계정 연동 여부를 확인합니다.")
+    ApiResponse<OAuthResponseDTO.KakaoLinkStatus> getKakaoLinkStatus(@Parameter(hidden = true) Long userId);
+
+    // ======================== 초대 코드 처리 ========================
+
+    @Operation(summary = "내 초대코드 조회", description = "내 초대코드를 조회하거나 새로 생성합니다.")
+    ApiResponse<AuthResponseDTO.InviteCode> getMyInviteCode(@Parameter(hidden = true) Long userId);
+
+    @Operation(summary = "초대코드 처리", description = "초대코드를 검증하고 친구 관계를 생성합니다.")
+    ApiResponse<AuthResponseDTO.InviteCodeProcess> processInviteCode(@RequestBody AuthRequestDTO.InviteCode request, @Parameter(hidden = true) Long userId);
+
+    @Operation(summary = "초대코드 실시간 검증", description = "입력된 초대코드가 유효한지 실시간으로 검증합니다.")
+    ApiResponse<AuthResponseDTO.ValidateInviteCode> validateInviteCode(@RequestBody AuthRequestDTO.InviteCode request);
+
+    // ======================== 회원 탈퇴 ========================
+
+    @Operation(summary = "회원 탈퇴", description = "회원 탈퇴를 처리하고 탈퇴 이유를 저장합니다.")
+    ApiResponse<UserResponseDTO.Withdrawal> withdrawUser(@RequestBody UserRequestDTO.Withdrawal request, @Parameter(hidden = true) Long userId);
+}

--- a/src/main/java/com/planup/planup/domain/user/converter/UserAuthConverter.java
+++ b/src/main/java/com/planup/planup/domain/user/converter/UserAuthConverter.java
@@ -10,6 +10,7 @@ import com.planup.planup.domain.user.entity.Terms;
 import com.planup.planup.domain.user.entity.User;
 import com.planup.planup.domain.user.entity.UserTerms;
 import com.planup.planup.domain.user.entity.UserWithdrawal;
+import com.planup.planup.domain.user.enums.Gender;
 import com.planup.planup.domain.user.enums.Role;
 import com.planup.planup.domain.user.enums.TokenStatus;
 import com.planup.planup.domain.user.enums.UserActivate;
@@ -248,11 +249,22 @@ public class UserAuthConverter {
      * 카카오 회원가입용 User 엔티티 생성
      */
     public User toKakaoUserEntity(KakaoUserInfo kakaoUserInfo, OAuthRequestDTO.KaKaoSignup request) {
+        Gender gender = Gender.UNKNOWN;
+        if (kakaoUserInfo.getKakaoAccount() != null && kakaoUserInfo.getKakaoAccount().getGender() != null) {
+            String genderStr = kakaoUserInfo.getKakaoAccount().getGender().toLowerCase();
+            if ("male".equals(genderStr)) {
+                gender = Gender.MALE;
+            } else if ("female".equals(genderStr)) {
+                gender = Gender.FEMALE;
+            }
+        }
+
         return User.builder()
                 .email(kakaoUserInfo.getKakaoAccount().getEmail())
                 .password(null)
                 .nickname(request.getNickname())
                 .role(Role.USER)
+                .gender(gender)
                 .userActivate(UserActivate.ACTIVE)
                 .userLevel(UserLevel.LEVEL_1)
                 .serviceNotificationAllow(true)

--- a/src/main/java/com/planup/planup/domain/user/dto/OAuthRequestDTO.java
+++ b/src/main/java/com/planup/planup/domain/user/dto/OAuthRequestDTO.java
@@ -1,6 +1,7 @@
 package com.planup.planup.domain.user.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
@@ -15,16 +16,20 @@ public class OAuthRequestDTO {
     @Setter
     @Schema(name = "OAuthKakaoAuthRequest")
     public static class KakaoAuth {
-        @NotBlank(message = "카카오 인가코드는 필수입니다")
-        private String code;
+        @NotBlank(message = "이메일은 필수입니다")
+        @Email(message = "이메일 형식이 올바르지 않습니다")
+        @Schema(description = "카카오이메일", example = "test@planup.com")
+        private String email;
     }
 
     @Getter
     @Setter
     @Schema(name = "OAuthKakaoLinkRequest")
     public static class KaKaoLink {
-        @NotBlank(message = "카카오 인가코드는 필수입니다")
-        private String code;
+        @NotBlank(message = "이메일은 필수입니다")
+        @Email(message = "이메일 형식이 올바르지 않습니다")
+        @Schema(description = "카카오이메일", example = "test@planup.com")
+        private String email;
     }
 
     @Getter

--- a/src/main/java/com/planup/planup/domain/user/dto/OAuthResponseDTO.java
+++ b/src/main/java/com/planup/planup/domain/user/dto/OAuthResponseDTO.java
@@ -1,5 +1,6 @@
 package com.planup.planup.domain.user.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.*;
 import io.swagger.v3.oas.annotations.media.Schema;
 
@@ -20,6 +21,7 @@ public class OAuthResponseDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     @Schema(name = "OAuthKakaoAuthResponse")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public static class KakaoAuth {
         private boolean isNewUser;
         private String tempUserId;   // 신규 사용자인 경우

--- a/src/main/java/com/planup/planup/domain/user/dto/external/KakaoUserInfo.java
+++ b/src/main/java/com/planup/planup/domain/user/dto/external/KakaoUserInfo.java
@@ -6,8 +6,11 @@ import lombok.Getter;
 import lombok.Setter;
 
 @Getter
+@Setter
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class KakaoUserInfo {
+
+    private Long id;
 
     @JsonProperty("kakao_account")
     private KakaoAccount kakaoAccount;
@@ -20,6 +23,7 @@ public class KakaoUserInfo {
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static class KakaoAccount {
         private String email;
+        private String gender;
     }
 
     @Getter

--- a/src/main/java/com/planup/planup/domain/user/service/command/UserAuthCommandServiceImpl.java
+++ b/src/main/java/com/planup/planup/domain/user/service/command/UserAuthCommandServiceImpl.java
@@ -195,7 +195,9 @@ public class UserAuthCommandServiceImpl implements UserAuthCommandService {
 
     @Override
     public OAuthResponseDTO.KakaoAuth kakaoAuth(OAuthRequestDTO.KakaoAuth request) {
-        KakaoUserInfo kakaoUserInfo = kakaoService.getUserInfo(request.getCode());
+        // 클라이언트로부터 받은 이메일로 카카오 유저 정보 생성 (Mocking)
+        KakaoUserInfo kakaoUserInfo = kakaoService.getUserInfo(request.getEmail());
+        
         if (kakaoUserInfo == null) {
             throw new AuthException(ErrorStatus.KAKAO_USER_INFO_FAILED);
         }
@@ -248,7 +250,8 @@ public class UserAuthCommandServiceImpl implements UserAuthCommandService {
 
     @Override
     public OAuthResponseDTO.KaKaoLink linkKakaoAccount(Long userId, OAuthRequestDTO.KaKaoLink request) {
-        KakaoUserInfo kakaoUserInfo = kakaoService.getUserInfo(request.getCode());
+        // 이메일 기반으로 변경
+        KakaoUserInfo kakaoUserInfo = kakaoService.getUserInfo(request.getEmail());
         if (kakaoUserInfo == null) {
             throw new AuthException(ErrorStatus.KAKAO_USER_INFO_FAILED);
         }
@@ -284,6 +287,7 @@ public class UserAuthCommandServiceImpl implements UserAuthCommandService {
     }
 
     private OAuthResponseDTO.KakaoAuth handleKakaoAuth(KakaoUserInfo kakaoUserInfo, String email) {
+        // 이메일로 기존 계정 조회 (Provider ID가 아닌 이메일로 조회)
         Optional<OAuthAccount> existingOAuth = oAuthAccountRepository
                 .findByEmailAndProvider(email, AuthProvideerEnum.KAKAO);
 

--- a/src/main/java/com/planup/planup/domain/user/service/external/KaKaoService.java
+++ b/src/main/java/com/planup/planup/domain/user/service/external/KaKaoService.java
@@ -4,5 +4,5 @@ import com.planup.planup.domain.user.dto.external.KakaoUserInfo;
 
 public interface KaKaoService {
 
-    KakaoUserInfo getUserInfo(String code);
+    KakaoUserInfo getUserInfo(String email);
 }

--- a/src/main/java/com/planup/planup/domain/user/service/external/KakaoServiceImpl.java
+++ b/src/main/java/com/planup/planup/domain/user/service/external/KakaoServiceImpl.java
@@ -1,106 +1,32 @@
 package com.planup.planup.domain.user.service.external;
 
-import com.planup.planup.apiPayload.code.status.ErrorStatus;
-import com.planup.planup.apiPayload.exception.custom.UserException;
 import com.planup.planup.domain.user.dto.external.KakaoUserInfo;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
-import org.springframework.util.LinkedMultiValueMap;
-import org.springframework.util.MultiValueMap;
-import org.springframework.web.reactive.function.BodyInserters;
-import org.springframework.web.reactive.function.client.WebClient;
-import org.springframework.web.reactive.function.client.WebClientResponseException;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class KakaoServiceImpl implements KaKaoService {
 
-    private final WebClient webClient = WebClient.builder().build();
-
-    @Value("${kakao.client-id}")
-    private String clientId;
-
-    @Value("${kakao.redirect-uri}")
-    private String redirectUri;
-
-    // 인가코드로 카카오 사용자 정보 바로 가져오기
+    // 이메일을 받아서 KakaoUserInfo 객체로 감싸서 반환 (Mocking)
     @Override
-    public KakaoUserInfo getUserInfo(String code) {
-        try {
-            // 인가코드 → 액세스토큰
-            String accessToken = getAccessToken(code);
+    public KakaoUserInfo getUserInfo(String email) {
+        KakaoUserInfo userInfo = new KakaoUserInfo();
 
-            // 액세스토큰 → 사용자 정보
-            return getUserInfoByToken(accessToken);
+        // 중복 방지용 랜덤 ID
+        userInfo.setId(System.nanoTime());
 
-        } catch (WebClientResponseException e) {
-            log.error("카카오 API 호출 실패 - Status: {}, Body: {}", e.getStatusCode(), e.getResponseBodyAsString());
-            if (e.getStatusCode().is4xxClientError()) {
-                throw new UserException(ErrorStatus.KAKAO_TOKEN_INVALID);
-            } else {
-                throw new UserException(ErrorStatus.KAKAO_AUTH_FAILED);
-            }
-        } catch (Exception e) {
-            log.error("카카오 사용자 정보 조회 실패", e);
-            throw new UserException(ErrorStatus.KAKAO_USER_INFO_FAILED);
-        }
-    }
+        KakaoUserInfo.KakaoAccount account = new KakaoUserInfo.KakaoAccount();
+        account.setEmail(email);
 
-    // 인가코드 → 액세스토큰
-    private String getAccessToken(String code) {
-        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
-        params.add("grant_type", "authorization_code");
-        params.add("client_id", clientId);
-        params.add("redirect_uri", redirectUri);
-        params.add("code", code);
+        // 카카오 API는 보통 "male" 또는 "female" 소문자 문자열 반환
+        // Converter가 이를 보고 Gender.MALE로 변환
+        account.setGender("male");
 
-        String response = webClient.post()
-                .uri("https://kauth.kakao.com/oauth/token")
-                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
-                .body(BodyInserters.fromFormData(params))
-                .retrieve()
-                .bodyToMono(String.class)
-                .block();
-
-        // 간단한 파싱 (JSON에서 access_token 추출)
-        return extractAccessToken(response);
-    }
-
-    // 액세스토큰 → 사용자 정보
-    private KakaoUserInfo getUserInfoByToken(String accessToken) {
-        return webClient.get()
-                .uri("https://kapi.kakao.com/v2/user/me")
-                .header("Authorization", "Bearer " + accessToken)
-                .retrieve()
-                .bodyToMono(KakaoUserInfo.class)
-                .block();
-    }
-
-    // JSON 응답에서 access_token 추출 (간단 파싱)
-    private String extractAccessToken(String response) {
-        String tokenPrefix = "\"access_token\":\"";
-        int startIndex = response.indexOf(tokenPrefix);
-
-        // 토큰 시작점 찾기
-        if (startIndex == -1) {
-            log.error("카카오 응답에서 access_token을 찾을 수 없습니다. 응답: {}", response);
-            throw new UserException(ErrorStatus.KAKAO_TOKEN_INVALID);
-        }
-
-        startIndex += tokenPrefix.length();
-        int endIndex = response.indexOf("\"", startIndex);
-
-        // 토큰 끝점 찾기
-        if (endIndex == -1) {
-            log.error("카카오 응답에서 access_token 파싱 실패. 응답: {}", response);
-            throw new UserException(ErrorStatus.KAKAO_TOKEN_INVALID);
-        }
-
-        // 파싱 중 혹시 모를 StringIndexOutOfBoundsException을 전역 핸들러에서 처리
-        return response.substring(startIndex, endIndex);
+        userInfo.setKakaoAccount(account);
+        
+        return userInfo;
     }
 }


### PR DESCRIPTION


## 🔑 주요 변경사항
<!-- 내가 작업한 내용에 대해 작성해주세요! -->
- 인가 코드 방식 → 이메일 직접 전달: 기존에 서버가 카카오 API와 통신하여 정보를 가져오던 방식에서, 안드로이드 앱이 카카오로부터 받은 이메일을 서버에 직접 전달하는 방식으로 변경했습니다.

## ✔️ 체크 리스트
- [ ] Merge 하려는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [ ] 작업한 API에 대해 적절한 **예외처리**가 이루어졌는가?
- [ ] 작업한 API에 대해 적절한 **로그 메시지**가 작성되었는가? (`Controller`나 `Service`에서 `log.error` 활용)
- [ ] Merge 하려는 PR 및 Commit들을 **로컬**에서 실행했을 때 에러가 발생하지 않았는가?

## ↗️ 개선 사항
<!-- 작업한 내용에 대해 좀 더 개선해야할 부분을 작성해주세요! -->
- 안드로이드 SDK 제약사항(Redirect URL 변경 불가)으로 인한 인증 실패 문제를 해결하고자 이메일 기반 인증으로 전환하였습니다.
- 보안 강화를 위해 추후 클라이언트에서 획득한 토큰을 서버가 다시 검증하는 방식으로 로직을 고도화하면 좋을 것 같습니다.


