### PR TITLE
[Feat] 유저 레벨 조회 api 개발 

### DIFF
--- a/src/main/java/com/planup/planup/domain/goal/controller/GoalController.java
+++ b/src/main/java/com/planup/planup/domain/goal/controller/GoalController.java
@@ -33,6 +33,13 @@ public class GoalController {
     private final UserQueryService userService;
     private final FriendReadService friendService;
 
+    @GetMapping("/level")
+    @Operation(summary = "유저 레벨 조회", description = "유저의 현재 레벨 정보를 조회합니다. 목표 생성 시 레벨별 제한을 확인하는 데 사용됩니다.")
+    public ApiResponse<GoalResponseDto.UserLevelInfo> getUserLevel(@Parameter(hidden = true) @CurrentUser Long userId) {
+        GoalResponseDto.UserLevelInfo userLevelInfo = goalService.getUserLevel(userId);
+        return ApiResponse.onSuccess(userLevelInfo);
+    }
+
     @PostMapping("/create")
     @Operation(summary = "목표 생성 API", description = "목표를 생성하는 API입니다.")
     public ApiResponse<GoalResponseDto.GoalResultDto> createGoal(

--- a/src/main/java/com/planup/planup/domain/goal/dto/GoalResponseDto.java
+++ b/src/main/java/com/planup/planup/domain/goal/dto/GoalResponseDto.java
@@ -2,6 +2,8 @@ package com.planup.planup.domain.goal.dto;
 
 import com.planup.planup.domain.goal.entity.Comment;
 import com.planup.planup.domain.goal.entity.Enum.*;
+import com.planup.planup.domain.user.entity.User;
+import com.planup.planup.domain.user.enums.UserLevel;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 
@@ -226,5 +228,21 @@ public class GoalResponseDto {
 
         @Schema(description = "업데이트된 반응 정보")
         private GoalReactionDto reactionData;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(name = "UserLevelResponse")
+    public static class UserLevelInfo {
+        @Schema(description = "유저 레벨", example = "LEVEL_1")
+        private UserLevel userLevel;
+
+        public static UserLevelInfo from(User user) {
+            return UserLevelInfo.builder()
+                    .userLevel(user.getUserLevel())
+                    .build();
+        }
     }
 }

--- a/src/main/java/com/planup/planup/domain/goal/service/GoalService.java
+++ b/src/main/java/com/planup/planup/domain/goal/service/GoalService.java
@@ -46,4 +46,6 @@ public interface GoalService {
 
     @Transactional(readOnly = true)
     List<User> getOtherMember(User user, Goal goal);
+
+    GoalResponseDto.UserLevelInfo getUserLevel(Long userId);
 }

--- a/src/main/java/com/planup/planup/domain/goal/service/GoalServiceImpl.java
+++ b/src/main/java/com/planup/planup/domain/goal/service/GoalServiceImpl.java
@@ -488,6 +488,13 @@ public class GoalServiceImpl implements GoalService{
                 .toList();
     }
 
+    @Override
+    @Transactional(readOnly = true)
+    public GoalResponseDto.UserLevelInfo getUserLevel(Long userId) {
+        User user = userQueryService.getUserByUserId(userId);
+        return GoalResponseDto.UserLevelInfo.from(user);
+    }
+
     private void validateGoalCreationLimit(User user) {
         if (user.getUserLevel() == UserLevel.LEVEL_MAX) {
             return;


### PR DESCRIPTION
\## 🚀 관련 이슈
<!-- 이슈 번호를 작성하여 종료시켜주세요 -->
- close #222 

## 🔑 주요 변경사항
<!-- 내가 작업한 내용에 대해 작성해주세요! -->
- User 레벨 조회 api 개발
- 프론트엔드에서 레벨 별 목표 제한을 걸어야 하는 상황. but 현재 유저의 레벨을 알 수 있는 api 가 없음.
- 레벨 정보만 반환을 하고, 그 외에 생성 제한은 프론트에서 처리하도록 위임.
* 참고사항
- 별도의 컨버터 작성 없이 DTO 내부에서 from 메서드를 통해 컨버터 대체

## ✔️ 체크 리스트
- [ ] Merge 하려는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [ ] 작업한 API에 대해 적절한 **예외처리**가 이루어졌는가?
- [ ] 작업한 API에 대해 적절한 **로그 메시지**가 작성되었는가? (`Controller`나 `Service`에서 `log.error` 활용)
- [ ] Merge 하려는 PR 및 Commit들을 **로컬**에서 실행했을 때 에러가 발생하지 않았는가?

## ↗️ 개선 사항
<!-- 작업한 내용에 대해 좀 더 개선해야할 부분을 작성해주세요! -->

## 📔 참고 자료
- 선택 사항
