### PR TITLE
[Refactor] : 목표 수정 시 목표 투자 시간 불러오기 수정

### DIFF
--- a/src/main/java/com/planup/planup/domain/goal/convertor/GoalConvertor.java
+++ b/src/main/java/com/planup/planup/domain/goal/convertor/GoalConvertor.java
@@ -62,9 +62,7 @@ public class GoalConvertor {
         Integer goalTime = null;
 
         if (goal.getVerificationType() == VerificationType.TIMER) {
-            if (!userGoal.getTimerVerifications().isEmpty()) {
-                goalTime = userGoal.getGoalTime();
-            }
+            goalTime = userGoal.getGoalTime();
         }
 
         return GoalResponseDto.GoalCreateListDto.builder()

--- a/src/main/java/com/planup/planup/domain/goal/service/GoalServiceImpl.java
+++ b/src/main/java/com/planup/planup/domain/goal/service/GoalServiceImpl.java
@@ -83,6 +83,9 @@ public class GoalServiceImpl implements GoalService{
         Goal goal = GoalConvertor.toGoal(createGoalDto);
         Goal savedGoal = goalRepository.save(goal);
 
+        int goalTime = (createGoalDto.getVerificationType() == VerificationType.TIMER && createGoalDto.getGoalTime() != null)
+                ? createGoalDto.getGoalTime() : 0;
+
         UserGoal userGoal = UserGoal.builder()
                 .user(User.builder().id(userId).build())
                 .goal(savedGoal)
@@ -91,6 +94,7 @@ public class GoalServiceImpl implements GoalService{
                 .isActive(true)
                 .isPublic(true)
                 .verificationCount(0)
+                .goalTime(goalTime)
                 .build();
         UserGoal savedUserGoal = userGoalRepository.save(userGoal);
 
@@ -193,7 +197,7 @@ public class GoalServiceImpl implements GoalService{
         Integer goalTime = null;
         if (goal.getVerificationType() == VerificationType.TIMER) {
             UserGoal userGoal = userGoalService.getByGoalIdAndUserId(goalId, userId);
-            if (userGoal != null && !userGoal.getTimerVerifications().isEmpty()) {
+            if (userGoal != null) {
                 goalTime = userGoal.getGoalTime();
             }
         }


### PR DESCRIPTION
\## 🚀 관련 이슈
<!-- 이슈 번호를 작성하여 종료시켜주세요 -->
- close #228  //

## 🔑 주요 변경사항
<!-- 내가 작업한 내용에 대해 작성해주세요! -->
현재
- 목표 수정 시 목표 투자 시간을 불러오지 못함
- 목표 투자 시간이 아닌, 기록된 시간 인증 시간을 불러오고 있음
- 인증된 시간이 아닌, 목표로 설정한 시간을 불러오도록 수정

수정
- 목표 생성시 받아온 GoalTime 필드 DB에 저장하도록 코드 수정
- 인증을 하지 않고 목표를 수정하더라도 goaltime 반환하도록 조건문 제거


## ✔️ 체크 리스트
- [ ] Merge 하려는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [ ] 작업한 API에 대해 적절한 **예외처리**가 이루어졌는가?
- [ ] 작업한 API에 대해 적절한 **로그 메시지**가 작성되었는가? (`Controller`나 `Service`에서 `log.error` 활용)
- [ ] Merge 하려는 PR 및 Commit들을 **로컬**에서 실행했을 때 에러가 발생하지 않았는가?

## ↗️ 개선 사항
<!-- 작업한 내용에 대해 좀 더 개선해야할 부분을 작성해주세요! -->

## 📔 참고 자료
- 선택 사항
