### PR TITLE
[Feat] 목표별 사진 CRUD api 개발

### DIFF
--- a/src/main/java/com/planup/planup/domain/friend/entity/reportEntity/UserReportMapping.java
+++ b/src/main/java/com/planup/planup/domain/friend/entity/reportEntity/UserReportMapping.java
@@ -4,10 +4,7 @@ package com.planup.planup.domain.friend.entity.reportEntity;
 import com.planup.planup.domain.global.entity.BaseTimeEntity;
 import com.planup.planup.domain.user.entity.User;
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import lombok.experimental.SuperBuilder;
 
 import java.time.LocalDateTime;
@@ -17,7 +14,6 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @SuperBuilder
 @AllArgsConstructor
-@Builder
 @Table(
         name = "user_report_mapping",
         indexes = {

--- a/src/main/java/com/planup/planup/domain/goal/entity/Challenge.java
+++ b/src/main/java/com/planup/planup/domain/goal/entity/Challenge.java
@@ -15,6 +15,7 @@ import lombok.experimental.SuperBuilder;
 public class Challenge extends Goal {
 
     @Enumerated(EnumType.STRING)
+    @Builder.Default
     private ChallengeStatus status = ChallengeStatus.REQUESTED;  // 거절/수락 상태
 
     private String penalty;

--- a/src/main/java/com/planup/planup/domain/goal/entity/mapping/UserGoal.java
+++ b/src/main/java/com/planup/planup/domain/goal/entity/mapping/UserGoal.java
@@ -6,17 +6,13 @@ import com.planup.planup.apiPayload.exception.custom.ChallengeException;
 import com.planup.planup.domain.global.entity.BaseTimeEntity;
 import com.planup.planup.domain.goal.entity.Enum.Status;
 import com.planup.planup.domain.goal.entity.Goal;
+import com.planup.planup.domain.goalphoto.entity.GoalPhoto;
 import com.planup.planup.domain.user.entity.User;
 import com.planup.planup.domain.verification.entity.PhotoVerification;
 import com.planup.planup.domain.verification.entity.TimerVerification;
-import com.planup.planup.domain.user.entity.User;
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.experimental.SuperBuilder;
 import lombok.*;
+import lombok.experimental.SuperBuilder;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -24,7 +20,6 @@ import java.util.List;
 @Entity
 @Getter
 @SuperBuilder
-@Builder
 @AllArgsConstructor
 @NoArgsConstructor
 @Table(
@@ -76,6 +71,10 @@ public class UserGoal extends BaseTimeEntity {
     @Builder.Default
     @OneToMany(mappedBy = "userGoal", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<PhotoVerification> photoVerifications = new ArrayList<>();
+
+    @Builder.Default
+    @OneToMany(mappedBy = "userGoal", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<GoalPhoto> goalPhotos = new ArrayList<>();
 
     public void setActive(boolean set, User user) {
         if (this.user.getId().equals(user.getId())) {

--- a/src/main/java/com/planup/planup/domain/goalphoto/controller/GoalPhotoController.java
+++ b/src/main/java/com/planup/planup/domain/goalphoto/controller/GoalPhotoController.java
@@ -1,0 +1,57 @@
+package com.planup.planup.domain.goalphoto.controller;
+
+import com.planup.planup.apiPayload.ApiResponse;
+import com.planup.planup.domain.goalphoto.dto.GoalPhotoResponseDto;
+import com.planup.planup.domain.goalphoto.service.GoalPhotoService;
+import com.planup.planup.validation.annotation.CurrentUser;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/goals")
+public class GoalPhotoController {
+
+    private final GoalPhotoService goalPhotoService;
+
+    @PostMapping("/{goalId}/photos")
+    @Operation(summary = "목표 사진 업로드", description = "특정 날짜에 목표 사진을 업로드합니다. 여러 장 가능.")
+    public ApiResponse<GoalPhotoResponseDto.UploadResultDto> uploadGoalPhotos(
+            @PathVariable Long goalId,
+            @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate date,
+            @RequestPart List<MultipartFile> files,
+            @CurrentUser Long userId) {
+
+        GoalPhotoResponseDto.UploadResultDto result = goalPhotoService.uploadGoalPhotos(userId, goalId, date, files);
+        return ApiResponse.onSuccess(result);
+    }
+
+    @GetMapping("/{goalId}/photos")
+    @Operation(summary = "목표 사진 조회", description = "특정 날짜의 목표 사진 목록을 조회합니다.")
+    public ApiResponse<GoalPhotoResponseDto.GoalPhotoListDto> getGoalPhotos(
+            @PathVariable Long goalId,
+            @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate date,
+            @CurrentUser Long userId) {
+
+        GoalPhotoResponseDto.GoalPhotoListDto result = goalPhotoService.getGoalPhotosByDate(userId, goalId, date);
+        return ApiResponse.onSuccess(result);
+    }
+
+    @DeleteMapping("/photos/{photoId}")
+    @Operation(summary = "목표 사진 삭제", description = "개별 목표 사진을 삭제합니다.")
+    public ApiResponse<Void> deleteGoalPhoto(
+            @Parameter(description = "사진 ID", example = "1")
+            @PathVariable Long photoId,
+            @CurrentUser Long userId) {
+
+        goalPhotoService.deleteGoalPhoto(userId, photoId);
+        return ApiResponse.onSuccess(null);
+    }
+}

--- a/src/main/java/com/planup/planup/domain/goalphoto/dto/GoalPhotoResponseDto.java
+++ b/src/main/java/com/planup/planup/domain/goalphoto/dto/GoalPhotoResponseDto.java
@@ -1,0 +1,56 @@
+package com.planup.planup.domain.goalphoto.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class GoalPhotoResponseDto {
+
+    @Builder
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(description = "개별 사진 정보")
+    public static class GoalPhotoDto {
+        @Schema(description = "사진 ID", example = "1")
+        private Long id;
+
+        @Schema(description = "사진 URL")
+        private String photoUrl;
+
+        @Schema(description = "생성 일시")
+        private LocalDateTime createdAt;
+    }
+
+    @Builder
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(description = "특정 날짜의 사진 목록")
+    public static class GoalPhotoListDto {
+        @Schema(description = "날짜")
+        private LocalDate date;
+
+        @Schema(description = "사진 목록")
+        private List<GoalPhotoDto> photos;
+    }
+
+    @Builder
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(description = "사진 업로드 결과")
+    public static class UploadResultDto {
+        @Schema(description = "날짜")
+        private LocalDate date;
+
+        @Schema(description = "업로드된 사진 목록")
+        private List<GoalPhotoDto> uploadedPhotos;
+    }
+}

--- a/src/main/java/com/planup/planup/domain/goalphoto/entity/GoalPhoto.java
+++ b/src/main/java/com/planup/planup/domain/goalphoto/entity/GoalPhoto.java
@@ -1,0 +1,39 @@
+package com.planup.planup.domain.goalphoto.entity;
+
+import com.planup.planup.domain.global.entity.BaseTimeEntity;
+import com.planup.planup.domain.goal.entity.mapping.UserGoal;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+import java.time.LocalDate;
+
+@Entity
+@Getter
+@SuperBuilder
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(
+        name = "goal_photo",
+        indexes = {
+                @Index(name = "idx_goal_photo_usergoal_date", columnList = "user_goal_id, date")
+        }
+)
+public class GoalPhoto extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String photoUrl;
+
+    @Column(nullable = false)
+    private LocalDate date;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_goal_id", nullable = false)
+    private UserGoal userGoal;
+}

--- a/src/main/java/com/planup/planup/domain/goalphoto/repository/GoalPhotoRepository.java
+++ b/src/main/java/com/planup/planup/domain/goalphoto/repository/GoalPhotoRepository.java
@@ -1,0 +1,17 @@
+package com.planup.planup.domain.goalphoto.repository;
+
+import com.planup.planup.domain.goal.entity.mapping.UserGoal;
+import com.planup.planup.domain.goalphoto.entity.GoalPhoto;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Repository
+public interface GoalPhotoRepository extends JpaRepository<GoalPhoto, Long> {
+
+    List<GoalPhoto> findAllByUserGoalAndDateOrderByCreatedAtDesc(UserGoal userGoal, LocalDate date);
+
+    void deleteAllByUserGoalAndDate(UserGoal userGoal, LocalDate date);
+}

--- a/src/main/java/com/planup/planup/domain/goalphoto/service/GoalPhotoService.java
+++ b/src/main/java/com/planup/planup/domain/goalphoto/service/GoalPhotoService.java
@@ -1,0 +1,89 @@
+package com.planup.planup.domain.goalphoto.service;
+
+import com.planup.planup.domain.global.service.ImageUploadService;
+import com.planup.planup.domain.goal.entity.mapping.UserGoal;
+import com.planup.planup.domain.goal.service.UserGoalService;
+import com.planup.planup.domain.goalphoto.dto.GoalPhotoResponseDto;
+import com.planup.planup.domain.goalphoto.entity.GoalPhoto;
+import com.planup.planup.domain.goalphoto.repository.GoalPhotoRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class GoalPhotoService {
+
+    private final GoalPhotoRepository goalPhotoRepository;
+    private final UserGoalService userGoalService;
+    private final ImageUploadService imageUploadService;
+
+    @Transactional
+    public GoalPhotoResponseDto.UploadResultDto uploadGoalPhotos(Long userId, Long goalId, LocalDate date, List<MultipartFile> files) {
+        UserGoal userGoal = userGoalService.getByGoalIdAndUserId(goalId, userId);
+
+        List<GoalPhotoResponseDto.GoalPhotoDto> uploadedPhotos = new ArrayList<>();
+
+        for (MultipartFile file : files) {
+            String photoUrl = imageUploadService.uploadImage(file, "goals/photos");
+
+            GoalPhoto goalPhoto = GoalPhoto.builder()
+                    .photoUrl(photoUrl)
+                    .date(date)
+                    .userGoal(userGoal)
+                    .build();
+
+            GoalPhoto saved = goalPhotoRepository.save(goalPhoto);
+
+            uploadedPhotos.add(GoalPhotoResponseDto.GoalPhotoDto.builder()
+                    .id(saved.getId())
+                    .photoUrl(saved.getPhotoUrl())
+                    .createdAt(saved.getCreatedAt())
+                    .build());
+        }
+
+        return GoalPhotoResponseDto.UploadResultDto.builder()
+                .date(date)
+                .uploadedPhotos(uploadedPhotos)
+                .build();
+    }
+
+    public GoalPhotoResponseDto.GoalPhotoListDto getGoalPhotosByDate(Long userId, Long goalId, LocalDate date) {
+        UserGoal userGoal = userGoalService.getByGoalIdAndUserId(goalId, userId);
+
+        List<GoalPhoto> photos = goalPhotoRepository.findAllByUserGoalAndDateOrderByCreatedAtDesc(userGoal, date);
+
+        List<GoalPhotoResponseDto.GoalPhotoDto> photoDtos = photos.stream()
+                .map(photo -> GoalPhotoResponseDto.GoalPhotoDto.builder()
+                        .id(photo.getId())
+                        .photoUrl(photo.getPhotoUrl())
+                        .createdAt(photo.getCreatedAt())
+                        .build())
+                .toList();
+
+        return GoalPhotoResponseDto.GoalPhotoListDto.builder()
+                .date(date)
+                .photos(photoDtos)
+                .build();
+    }
+
+    @Transactional
+    public void deleteGoalPhoto(Long userId, Long photoId) {
+        GoalPhoto goalPhoto = goalPhotoRepository.findById(photoId)
+                .orElseThrow(() -> new IllegalArgumentException("사진을 찾을 수 없습니다."));
+
+        UserGoal userGoal = goalPhoto.getUserGoal();
+        if (!userGoal.getUser().getId().equals(userId)) {
+            throw new IllegalArgumentException("해당 사진에 대한 권한이 없습니다.");
+        }
+
+        imageUploadService.deleteImage(goalPhoto.getPhotoUrl());
+        goalPhotoRepository.delete(goalPhoto);
+    }
+}

--- a/src/main/java/com/planup/planup/domain/verification/service/PhotoVerificationService.java
+++ b/src/main/java/com/planup/planup/domain/verification/service/PhotoVerificationService.java
@@ -73,6 +73,7 @@ public class PhotoVerificationService implements VerificationService {
             userGoalRepository.save(userGoal);
         }
 
+        imageUploadService.deleteImage(verification.getPhotoImg());
         photoVerificationRepository.delete(verification);
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -36,6 +36,11 @@ spring:
     database-platform: org.hibernate.dialect.MySQLDialect
 
 
+  servlet:
+    multipart:
+      max-file-size: 5MB
+      max-request-size: 50MB
+
   application:
     name: planup
 


### PR DESCRIPTION
\## 🚀 관련 이슈
<!-- 이슈 번호를 작성하여 종료시켜주세요 -->
- close #227  //

## 🔑 주요 변경사항
<!-- 내가 작업한 내용에 대해 작성해주세요! -->
- 목표(Goal)에 날짜별 사진을 업로드/조회/삭제할 수 있는 기능을 추가
- 기존 코드에서 발견된 S3 업로드 관련 버그 및 Lombok 어노테이션 충돌 문제를 수정

목표 사진 업로드 (GoalPhoto)
  - `POST /goals/{goalId}/photos` — 특정 날짜에 사진 다중 업로드 (S3 저장 후 URL DB 저장)
  - `GET /goals/{goalId}/photos?date=yyyy-MM-dd` — 날짜별 사진 목록 조회
  - `DELETE /goals/photos/{photoId}` — 개별 사진 삭제 (S3 이미지 동시 삭제)
  - `UserGoal`과 `@OneToMany` 연관관계로 날짜별 사진 관리

 1. S3 사진 업로드 실패 (application.yml)
  - Spring Boot 기본 multipart 제한(1MB)이 설정되어 있지 않아
    실제로 스마트폰 사진(2~5MB) 업로드 시 서비스 레이어에 도달하기 전에 에러 발생
  - `ImageUploadService`의 5MB 제한 로직이 사실상 동작하지 않던 문제 해결

  ### 2. Challenge 생성 시 status가 null이 되는 버그 (Challenge.java)
  - `@SuperBuilder` 사용 시 초기화 표현식(`= ChallengeStatus.REQUESTED`)이 무시됨
  - `@Builder.Default` 추가로 빌더로 생성해도 기본값 `REQUESTED` 보장

  ### 3. Lombok 어노테이션 충돌 (UserGoal.java, UserReportMapping.java)
  - `@SuperBuilder`와 `@Builder`를 동시에 선언하여 컴파일 경고 및 `@Builder.Default` 오동작 발생
  - `@Builder` 제거 및 중복 import 정리

## ✔️ 체크 리스트
- [ ] Merge 하려는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [ ] 작업한 API에 대해 적절한 **예외처리**가 이루어졌는가?
- [ ] 작업한 API에 대해 적절한 **로그 메시지**가 작성되었는가? (`Controller`나 `Service`에서 `log.error` 활용)
- [ ] Merge 하려는 PR 및 Commit들을 **로컬**에서 실행했을 때 에러가 발생하지 않았는가?

## ↗️ 개선 사항
<!-- 작업한 내용에 대해 좀 더 개선해야할 부분을 작성해주세요! -->

## 📔 참고 자료
- 선택 사항
