### PR TITLE
[Refactor] 개인 목표 조회 시 활성화 여부 필드 반환 추가

### DIFF
--- a/src/main/java/com/planup/planup/domain/goal/convertor/GoalConvertor.java
+++ b/src/main/java/com/planup/planup/domain/goal/convertor/GoalConvertor.java
@@ -91,6 +91,7 @@ public class GoalConvertor {
                 .goalType(goal.getGoalType())
                 .frequency(goal.getFrequency())
                 .oneDose(goal.getOneDose())
+                .isActive(userGoal.isActive())
                 .build();
     }
 

--- a/src/main/java/com/planup/planup/domain/goal/dto/GoalResponseDto.java
+++ b/src/main/java/com/planup/planup/domain/goal/dto/GoalResponseDto.java
@@ -4,6 +4,7 @@ import com.planup.planup.domain.goal.entity.Comment;
 import com.planup.planup.domain.goal.entity.Enum.*;
 import com.planup.planup.domain.user.entity.User;
 import com.planup.planup.domain.user.enums.UserLevel;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 
@@ -62,6 +63,8 @@ public class GoalResponseDto {
         private GoalType goalType;
         private int frequency;
         private int oneDose;
+        @JsonProperty("isActive")
+        private boolean isActive;
     }
 
     //친구 목표 조회 리스트 Dto


### PR DESCRIPTION
\## 🚀 관련 이슈
<!-- 이슈 번호를 작성하여 종료시켜주세요 -->
- close #234  //

## 🔑 주요 변경사항
<!-- 내가 작업한 내용에 대해 작성해주세요! -->

## Summary                     

 - `/goals/mygoal/list` API의 `isActive` 필드추가 
 - JSON 응답에서 `active`로 직렬화되는 문제 수정
                                                                         
  ## 문제 원인    

  `MyGoalListDto`에서 `private boolean isActive` + Lombok `@Data` 조합   
  사용 시

  - Lombok이 primitive `boolean` 필드에 대해 getter를 `isActive()`로 생성
  - Jackson은 `is` prefix가 붙은 getter를 발견하면 `is`를 제거하고 직렬화
  - 결과적으로 JSON 응답에서 `"isActive"` 가 아닌 `"active"` 로 내려가는 문제가 있음 

  ## 해결 방법 비교

  | 방법 | 설명 | 단점 |
  |------|------|------|
  | `@JsonProperty("isActive")` | JSON key 이름을 명시적으로 강제 지정 | 없음 |
  | `Boolean` (wrapper 타입)으로 변경 | getter가 `getIsActive()`가 되어   `isActive`로 직렬화 | null 가능 → NPE 위험 |

  → null 안전성을 위해 `@JsonProperty("isActive")` 채택

  ## 변경 사항

  - `GoalResponseDto.MyGoalListDto` - `isActive` 필드에
  `@JsonProperty("isActive")` 추가
  - `GoalConvertor.toMyGoalListDto` - `isActive` 필드 매핑 누락 추가     



## ✔️ 체크 리스트
- [ ] Merge 하려는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [ ] 작업한 API에 대해 적절한 **예외처리**가 이루어졌는가?
- [ ] 작업한 API에 대해 적절한 **로그 메시지**가 작성되었는가? (`Controller`나 `Service`에서 `log.error` 활용)
- [ ] Merge 하려는 PR 및 Commit들을 **로컬**에서 실행했을 때 에러가 발생하지 않았는가?

## ↗️ 개선 사항
<!-- 작업한 내용에 대해 좀 더 개선해야할 부분을 작성해주세요! -->

## 📔 참고 자료
- 선택 사항
