### PR TITLE
[FEAT] 유저 신고 누적에 따른 자동 제재 로직 구현

### DIFF
--- a/src/main/java/com/planup/planup/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/planup/planup/apiPayload/code/status/ErrorStatus.java
@@ -52,6 +52,9 @@ public enum ErrorStatus implements BaseErrorCode {
     INVALID_EMAIL_FORMAT(HttpStatus.BAD_REQUEST, "USER4009", "이메일 형식이 올바르지 않거나 비어있습니다."),
     PASSWORD_TOKEN_INVALID(BAD_REQUEST, "AUTH4002", "만료되거나 유효하지 않은 비밀번호 변경 토큰입니다."),
     DUPLICATE_EMAIL_ACCOUNT(HttpStatus.CONFLICT, "USER4010", "이미 일반 계정으로 가입된 이메일입니다"),
+    USER_SUSPENDED(HttpStatus.FORBIDDEN, "USER4011", "정지된 계정입니다."),
+    USER_SANCTIONED_DELETED(HttpStatus.FORBIDDEN, "USER4012", "삭제된 계정입니다."),
+    EMAIL_BLOCKED_BY_SANCTION(HttpStatus.FORBIDDEN, "USER4013", "제재로 인해 해당 이메일로 가입할 수 없습니다."),
 
     //Challenge 에러
     MISSING_TIME_CHALLENGE_INFO(HttpStatus.BAD_REQUEST, "CHALLENGE4001", "시간 챌린지 정보가 필요합니다."),

--- a/src/main/java/com/planup/planup/apiPayload/exception/ExceptionAdvice.java
+++ b/src/main/java/com/planup/planup/apiPayload/exception/ExceptionAdvice.java
@@ -4,6 +4,8 @@ import com.planup.planup.apiPayload.ApiResponse;
 import com.planup.planup.apiPayload.code.ErrorReasonDTO;
 import com.planup.planup.apiPayload.code.status.ErrorStatus;
 import com.planup.planup.apiPayload.exception.custom.TokenException;
+import com.planup.planup.apiPayload.exception.custom.UserSuspendedException;
+import com.planup.planup.domain.user.dto.UserResponseDTO;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.ConstraintViolationException;
 import lombok.extern.slf4j.Slf4j;
@@ -69,6 +71,16 @@ public class ExceptionAdvice extends ResponseEntityExceptionHandler {
     @ExceptionHandler(value = IllegalArgumentException.class)
     public ResponseEntity<Object> handleIllegalArgumentException(IllegalArgumentException e, HttpServletRequest request) {
         return handleExceptionInternalConstraint(e, ErrorStatus.INVALID_EMAIL_TOKEN, HttpHeaders.EMPTY, new ServletWebRequest(request));
+    }
+
+    @ExceptionHandler(value = UserSuspendedException.class)
+    public ResponseEntity<Object> handleUserSuspendedException(UserSuspendedException ex, HttpServletRequest request) {
+        ErrorReasonDTO reason = ex.getErrorReasonHttpStatus();
+        ApiResponse<UserResponseDTO.SanctionInfo> body = ApiResponse.onFailure(
+                reason.getCode(), reason.getMessage(), ex.getSanctionInfo()
+        );
+        WebRequest webRequest = new ServletWebRequest(request);
+        return super.handleExceptionInternal(ex, body, null, reason.getHttpStatus(), webRequest);
     }
 
     @ExceptionHandler(value = TokenException.class)

--- a/src/main/java/com/planup/planup/apiPayload/exception/custom/UserSuspendedException.java
+++ b/src/main/java/com/planup/planup/apiPayload/exception/custom/UserSuspendedException.java
@@ -1,0 +1,23 @@
+package com.planup.planup.apiPayload.exception.custom;
+
+import com.planup.planup.apiPayload.code.BaseErrorCode;
+import com.planup.planup.apiPayload.exception.GeneralException;
+import com.planup.planup.domain.user.dto.UserResponseDTO;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class UserSuspendedException extends GeneralException {
+
+    private final UserResponseDTO.SanctionInfo sanctionInfo;
+
+    public UserSuspendedException(BaseErrorCode code, LocalDateTime sanctionEndAt, String sanctionReason) {
+        super(code);
+        this.sanctionInfo = UserResponseDTO.SanctionInfo.builder()
+                .sanctionStatus("SUSPENDED")
+                .sanctionEndAt(sanctionEndAt)
+                .sanctionReason(sanctionReason)
+                .build();
+    }
+}

--- a/src/main/java/com/planup/planup/domain/friend/repository/UserReportMappingRepository.java
+++ b/src/main/java/com/planup/planup/domain/friend/repository/UserReportMappingRepository.java
@@ -2,8 +2,20 @@ package com.planup.planup.domain.friend.repository;
 
 import com.planup.planup.domain.friend.entity.reportEntity.UserReportMapping;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
 
 public interface UserReportMappingRepository extends JpaRepository<UserReportMapping, Long> {
 
-
+    @Query("""
+            SELECT r.reason
+            FROM UserReportMapping r
+            WHERE r.reported.id = :reportedId AND r.reason IS NOT NULL
+            GROUP BY r.reason
+            ORDER BY COUNT(r.reason) DESC
+            LIMIT 1
+            """)
+    Optional<String> findTopReasonByReportedId(@Param("reportedId") Long reportedId);
 }

--- a/src/main/java/com/planup/planup/domain/friend/service/reportUserService/UserReportMappingServiceImpl.java
+++ b/src/main/java/com/planup/planup/domain/friend/service/reportUserService/UserReportMappingServiceImpl.java
@@ -39,7 +39,22 @@ public class UserReportMappingServiceImpl implements UserReportMappingService {
                 .status(ReportStatus.PENDING)
                 .build();
 
-        userReportMappingRepository.save(userReport);
+        userReportMappingRepository.saveAndFlush(userReport);
+
+        reported.incrementReportCount();
+
+        String topReason = userReportMappingRepository
+                .findTopReasonByReportedId(reported.getId())
+                .orElse(reason);
+
+        if (reported.getReportCount() >= 5) {
+            reported.applyDeletion(topReason);
+        } else if (reported.getReportCount() >= 3) {
+            reported.applySuspension(topReason);
+        } else {
+            reported.updateSanctionReason(topReason);
+        }
+
         return true;
     }
 }

--- a/src/main/java/com/planup/planup/domain/user/dto/UserResponseDTO.java
+++ b/src/main/java/com/planup/planup/domain/user/dto/UserResponseDTO.java
@@ -11,6 +11,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 public class UserResponseDTO {
 
@@ -97,6 +98,23 @@ public class UserResponseDTO {
     public static class RandomNickname {
         @Schema(description = "랜덤 닉네임", example = "행복한고양이")
         private String nickname;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @Schema(name = "UserSanctionInfo")
+    public static class SanctionInfo {
+        @Schema(description = "제재 상태", example = "SUSPENDED")
+        private String sanctionStatus;
+
+        @Schema(description = "제재 종료일")
+        private LocalDateTime sanctionEndAt;
+
+        @Schema(description = "제재 사유")
+        private String sanctionReason;
     }
 
     @Getter

--- a/src/main/java/com/planup/planup/domain/user/entity/User.java
+++ b/src/main/java/com/planup/planup/domain/user/entity/User.java
@@ -94,6 +94,14 @@ public class User extends BaseTimeEntity {
     @Column(name = "email_verified_at")
     private LocalDateTime emailVerifiedAt;
 
+    @Column(nullable = false)
+    @Builder.Default
+    private int reportCount = 0;
+
+    private LocalDateTime sanctionEndAt;
+
+    private String sanctionReason;
+
     // 연관 관계
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
     @Builder.Default
@@ -166,5 +174,35 @@ public class User extends BaseTimeEntity {
             userStat.setUser(this);
         }
         return userStat;
+    }
+
+    public void incrementReportCount() {
+        this.reportCount++;
+    }
+
+    public void applySuspension(String reason) {
+        this.userActivate = UserActivate.SUSPENDED;
+        this.sanctionEndAt = LocalDateTime.now().plusDays(14);
+        this.sanctionReason = reason;
+    }
+
+    public void applyDeletion(String reason) {
+        this.userActivate = UserActivate.DELETED;
+        this.sanctionEndAt = LocalDateTime.now().plusDays(90);
+        this.sanctionReason = reason;
+    }
+
+    public void liftSuspensionIfExpired() {
+        if (this.userActivate == UserActivate.SUSPENDED
+                && this.sanctionEndAt != null
+                && LocalDateTime.now().isAfter(this.sanctionEndAt)) {
+            this.userActivate = UserActivate.ACTIVE;
+            this.sanctionEndAt = null;
+            this.sanctionReason = null;
+        }
+    }
+
+    public void updateSanctionReason(String reason) {
+        this.sanctionReason = reason;
     }
 }

--- a/src/main/java/com/planup/planup/domain/user/enums/UserActivate.java
+++ b/src/main/java/com/planup/planup/domain/user/enums/UserActivate.java
@@ -3,6 +3,7 @@ package com.planup.planup.domain.user.enums;
 public enum UserActivate {
     ACTIVE("활성화"),
     INACTIVE("비활성화"),
+    SUSPENDED("잠금"),
     DELETED("삭제");
 
     private final String description;

--- a/src/main/java/com/planup/planup/domain/user/service/command/UserAuthCommandServiceImpl.java
+++ b/src/main/java/com/planup/planup/domain/user/service/command/UserAuthCommandServiceImpl.java
@@ -4,6 +4,7 @@ import com.planup.planup.apiPayload.code.status.ErrorStatus;
 import com.planup.planup.apiPayload.exception.custom.AuthException;
 import com.planup.planup.apiPayload.exception.custom.FriendException;
 import com.planup.planup.apiPayload.exception.custom.UserException;
+import com.planup.planup.apiPayload.exception.custom.UserSuspendedException;
 import com.planup.planup.domain.bedge.entity.UserStat;
 import com.planup.planup.domain.friend.entity.Friend;
 import com.planup.planup.domain.friend.entity.FriendStatus;
@@ -135,8 +136,14 @@ public class UserAuthCommandServiceImpl implements UserAuthCommandService {
 
     @Override
     public UserResponseDTO.AuthResponseDTO login(UserRequestDTO.Login request) {
-        User user = userRepository.findByEmailAndUserActivate(request.getEmail(), UserActivate.ACTIVE)
+        User user = userRepository.findByEmail(request.getEmail())
                 .orElseThrow(() -> new UserException(ErrorStatus.NOT_FOUND_USER));
+
+        checkSanction(user);
+
+        if (user.getUserActivate() != UserActivate.ACTIVE) {
+            throw new UserException(ErrorStatus.NOT_FOUND_USER);
+        }
 
         if (!passwordEncoder.matches(request.getPassword(), user.getPassword())) {
             throw new UserException(ErrorStatus.INVALID_CREDENTIALS);
@@ -175,6 +182,22 @@ public class UserAuthCommandServiceImpl implements UserAuthCommandService {
 
         log.info("사용자 {} 회원 탈퇴 완료. 이유: {}", user.getNickname(), request.getReason());
         return userAuthConverter.toWithdrawalResponseDTO(true, "회원 탈퇴가 완료되었습니다.", LocalDateTime.now().toString());
+    }
+
+    private void checkSanction(User user) {
+        if (user.getUserActivate() == UserActivate.DELETED) {
+            throw new UserException(ErrorStatus.USER_SANCTIONED_DELETED);
+        }
+        if (user.getUserActivate() == UserActivate.SUSPENDED) {
+            user.liftSuspensionIfExpired();
+            if (user.getUserActivate() == UserActivate.SUSPENDED) {
+                throw new UserSuspendedException(
+                        ErrorStatus.USER_SUSPENDED,
+                        user.getSanctionEndAt(),
+                        user.getSanctionReason()
+                );
+            }
+        }
     }
 
     private void cleanupUserData(User user) {
@@ -227,6 +250,8 @@ public class UserAuthCommandServiceImpl implements UserAuthCommandService {
             }
 
             // 로그인 진행 (KAKAO 타입인 경우)
+            checkSanction(user);
+
             if (user.getUserActivate() != UserActivate.ACTIVE) {
                 throw new UserException(ErrorStatus.USER_INACTIVE);
             }

--- a/src/main/java/com/planup/planup/domain/user/service/query/UserQueryService.java
+++ b/src/main/java/com/planup/planup/domain/user/service/query/UserQueryService.java
@@ -16,7 +16,6 @@ public interface UserQueryService {
     // 이메일 검증
     void checkEmail(String email);  // 회원가입용 중복 체크
     void checkEmailExists(String email);  // 비밀번호 변경용 존재 확인
-    boolean isEmailAvailable(String email);
     AuthResponseDTO.EmailDuplicate checkEmailDuplicate(String email);
 
     // 닉네임

--- a/src/main/java/com/planup/planup/domain/user/service/query/UserQueryServiceImpl.java
+++ b/src/main/java/com/planup/planup/domain/user/service/query/UserQueryServiceImpl.java
@@ -24,6 +24,7 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.Random;
@@ -72,6 +73,13 @@ public class UserQueryServiceImpl implements UserQueryService {
         if (userRepository.existsByEmailAndUserActivate(email, UserActivate.ACTIVE)) {
             throw new UserException(ErrorStatus.USER_EMAIL_ALREADY_EXISTS);
         }
+        Optional<User> deletedUser = userRepository.findByEmailAndUserActivate(email, UserActivate.DELETED);
+        if (deletedUser.isPresent()) {
+            LocalDateTime unblockAt = deletedUser.get().getSanctionEndAt();
+            if (unblockAt != null && LocalDateTime.now().isBefore(unblockAt)) {
+                throw new UserException(ErrorStatus.EMAIL_BLOCKED_BY_SANCTION);
+            }
+        }
     }
 
     @Override
@@ -83,17 +91,18 @@ public class UserQueryServiceImpl implements UserQueryService {
     }
 
     @Override
-    public boolean isEmailAvailable(String email) {
-        return !userRepository.existsByEmailAndUserActivate(email, UserActivate.ACTIVE);
-    }
-
-    @Override
     public AuthResponseDTO.EmailDuplicate checkEmailDuplicate(String email) {
-        boolean isAvailable = isEmailAvailable(email);
-        return userAuthConverter.toEmailDuplicateResponseDTO(
-                isAvailable,
-                isAvailable ? "사용 가능한 이메일입니다." : "이미 사용 중인 이메일입니다."
-        );
+        if (userRepository.existsByEmailAndUserActivate(email, UserActivate.ACTIVE)) {
+            return userAuthConverter.toEmailDuplicateResponseDTO(false, "이미 사용 중인 이메일입니다.");
+        }
+        Optional<User> deletedUser = userRepository.findByEmailAndUserActivate(email, UserActivate.DELETED);
+        if (deletedUser.isPresent()) {
+            LocalDateTime unblockAt = deletedUser.get().getSanctionEndAt();
+            if (unblockAt != null && LocalDateTime.now().isBefore(unblockAt)) {
+                throw new UserException(ErrorStatus.EMAIL_BLOCKED_BY_SANCTION);
+            }
+        }
+        return userAuthConverter.toEmailDuplicateResponseDTO(true, "사용 가능한 이메일입니다.");
     }
 
     // ========== 닉네임 ==========


### PR DESCRIPTION

## 🚀 관련 이슈
<!-- 이슈 번호를 작성하여 종료시켜주세요 -->
- close #237 

## 🔑 주요 변경사항
<!-- 내가 작업한 내용에 대해 작성해주세요! -->
- User 엔티티 내 신고 횟수 및 제재 관련 필드 추가
- 신고 3회(정지), 5회(삭제) 자동 처리 로직 구현
- 로그인 시 제재 상태 검증 및 전용 예외(UserSuspendedException) 추가
- 제재로 인한 삭제 시 90일간 재가입 제한 로직 적용

## ✔️ 체크 리스트
- [ ] Merge 하려는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [ ] 작업한 API에 대해 적절한 **예외처리**가 이루어졌는가?
- [ ] 작업한 API에 대해 적절한 **로그 메시지**가 작성되었는가? (`Controller`나 `Service`에서 `log.error` 활용)
- [ ] Merge 하려는 PR 및 Commit들을 **로컬**에서 실행했을 때 에러가 발생하지 않았는가?

## ↗️ 개선 사항
<!-- 작업한 내용에 대해 좀 더 개선해야할 부분을 작성해주세요! -->
추후 관리자 페이지 도입한다면 차단 및 정지 기능 관리할 수 있는 API가 필요할 것 같습니다.

## 📔 참고 자료
<img width="1433" height="1300" alt="image" src="https://github.com/user-attachments/assets/5d05c9d4-ac57-4e21-9008-2262866162c2" />
<img width="1439" height="1262" alt="image" src="https://github.com/user-attachments/assets/955b8fce-496b-442d-9b45-f8bd1f01fd16" />
<img width="1447" height="995" alt="image" src="https://github.com/user-attachments/assets/adaa8982-c7fd-4622-b848-1deaf409b101" />
