### PR TITLE
[FIX] 이메일 중복 체크 시 계정 상태에 따른 케이스 분기 추가

### DIFF
--- a/src/main/java/com/planup/planup/domain/user/service/query/UserQueryServiceImpl.java
+++ b/src/main/java/com/planup/planup/domain/user/service/query/UserQueryServiceImpl.java
@@ -3,6 +3,7 @@ package com.planup.planup.domain.user.service.query;
 import com.planup.planup.apiPayload.code.status.ErrorStatus;
 import com.planup.planup.apiPayload.exception.custom.AuthException;
 import com.planup.planup.apiPayload.exception.custom.UserException;
+import com.planup.planup.apiPayload.exception.custom.UserSuspendedException;
 import com.planup.planup.domain.user.converter.TermsConverter;
 import com.planup.planup.domain.user.converter.UserAuthConverter;
 import com.planup.planup.domain.user.converter.UserProfileConverter;
@@ -92,16 +93,40 @@ public class UserQueryServiceImpl implements UserQueryService {
 
     @Override
     public AuthResponseDTO.EmailDuplicate checkEmailDuplicate(String email) {
-        if (userRepository.existsByEmailAndUserActivate(email, UserActivate.ACTIVE)) {
-            return userAuthConverter.toEmailDuplicateResponseDTO(false, "이미 사용 중인 이메일입니다.");
-        }
-        Optional<User> deletedUser = userRepository.findByEmailAndUserActivate(email, UserActivate.DELETED);
-        if (deletedUser.isPresent()) {
-            LocalDateTime unblockAt = deletedUser.get().getSanctionEndAt();
-            if (unblockAt != null && LocalDateTime.now().isBefore(unblockAt)) {
-                throw new UserException(ErrorStatus.EMAIL_BLOCKED_BY_SANCTION);
+        Optional<User> userOpt = userRepository.findByEmail(email);
+
+        if (userOpt.isPresent()) {
+            User user = userOpt.get();
+
+            if (user.getUserActivate() == UserActivate.DELETED) {
+                LocalDateTime unblockAt = user.getSanctionEndAt();
+                if (unblockAt != null && LocalDateTime.now().isBefore(unblockAt)) {
+                    throw new UserSuspendedException(
+                            ErrorStatus.USER_SANCTIONED_DELETED,
+                            "DELETED",
+                            user.getSanctionEndAt(),
+                            user.getSanctionReason()
+                    );
+                }
+            }
+
+            if (user.getUserActivate() == UserActivate.SUSPENDED) {
+                user.liftSuspensionIfExpired();
+                if (user.getUserActivate() == UserActivate.SUSPENDED) {
+                    throw new UserSuspendedException(
+                            ErrorStatus.USER_SUSPENDED,
+                            "SUSPENDED",
+                            user.getSanctionEndAt(),
+                            user.getSanctionReason()
+                    );
+                }
+            }
+
+            if (user.getUserActivate() == UserActivate.ACTIVE) {
+                return userAuthConverter.toEmailDuplicateResponseDTO(false, "이미 사용 중인 이메일입니다.");
             }
         }
+
         return userAuthConverter.toEmailDuplicateResponseDTO(true, "사용 가능한 이메일입니다.");
     }
 


### PR DESCRIPTION
## 🚀 관련 이슈
<!-- 이슈 번호를 작성하여 종료시켜주세요 -->
- close #237

## 🔑 주요 변경사항
<!-- 내가 작업한 내용에 대해 작성해주세요! -->
- 이메일 중복 검사 API에서 정지/삭제 계정 조회 시 로그인 API와 동일하게 UserSuspendedException을 통해 제재 정보(sanctionStatus, sanctionEndAt, sanctionReason)를 응답에 포함하도록 수정. 
- 기존에 누락되어 있던 SUSPENDED 상태 체크 로직도 함께 추가. 

## ✔️ 체크 리스트
- [ ] Merge 하려는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [ ] 작업한 API에 대해 적절한 **예외처리**가 이루어졌는가?
- [ ] 작업한 API에 대해 적절한 **로그 메시지**가 작성되었는가? (`Controller`나 `Service`에서 `log.error` 활용)
- [ ] Merge 하려는 PR 및 Commit들을 **로컬**에서 실행했을 때 에러가 발생하지 않았는가?

## ↗️ 개선 사항
<!-- 작업한 내용에 대해 좀 더 개선해야할 부분을 작성해주세요! -->

## 📔 참고 자료
- 선택 사항
